### PR TITLE
Fix bug in ECS queries

### DIFF
--- a/source/library/ecs/private/world.cpp
+++ b/source/library/ecs/private/world.cpp
@@ -292,10 +292,10 @@ auto up::World::_findArchetypeIndex(view<ComponentMeta const*> components) noexc
     return archetypeIndex;
 }
 
-void up::World::selectRaw(view<ComponentId> sortedComponents, delegate_ref<RawSelectSignature> callback) const {
+void up::World::selectRaw(view<ComponentId> sortedComponents, view<ComponentId> callbackComponents, delegate_ref<RawSelectSignature> callback) const {
     for (uint32 index = 0; index != _archetypes.size(); ++index) {
         if (_matchArchetype(index, sortedComponents)) {
-            _selectChunksRaw(index, sortedComponents, callback);
+            _selectChunksRaw(index, callbackComponents, callback);
         }
     }
 }

--- a/source/library/ecs/public/potato/ecs/world.h
+++ b/source/library/ecs/public/potato/ecs/world.h
@@ -71,7 +71,7 @@ namespace up {
         /// This is a type-unsafe variant of getComponentSlow.
         UP_ECS_API void* getComponentSlowUnsafe(EntityId entity, ComponentId component) noexcept;
 
-        UP_ECS_API void selectRaw(view<ComponentId> sortedComponents, delegate_ref<RawSelectSignature> callback) const;
+        UP_ECS_API void selectRaw(view<ComponentId> sortedComponents, view<ComponentId> callbackComponents, delegate_ref<RawSelectSignature> callback) const;
 
     private:
         UP_ECS_API EntityId _createEntityRaw(view<ComponentMeta const*> components, view<void const*> data);


### PR DESCRIPTION
The reverse mapping of indices was totally botched.

Instead now we simplify by storing both the sorted components for
matching and the original-order components for lookup/unpacking.