### PR TITLE
ECS fix for layout calculations

### DIFF
--- a/source/library/ecs/private/archetype.h
+++ b/source/library/ecs/private/archetype.h
@@ -18,7 +18,7 @@ struct up::World::Archetype {
 
     int32 indexOfLayout(ComponentId component) const noexcept {
         for (int32 i = 0; i != static_cast<int32>(layout.size()); ++i) {
-            if (layout[i].meta->id == component) {
+            if (layout[i].component == component) {
                 return i;
             }
         }

--- a/source/library/ecs/public/potato/ecs/query.h
+++ b/source/library/ecs/public/potato/ecs/query.h
@@ -36,9 +36,8 @@ namespace up {
         void select(World& world, Delegate callback) const;
 
     private:
-        void _invoke(size_t count, EntityId const* entities, view<void*> pointers, Delegate callback) const;
         template <size_t... Indices>
-        void _invokeHelper(std::index_sequence<Indices...>, size_t, EntityId const*, view<void*>, Delegate callback) const;
+        void _invoke(std::index_sequence<Indices...>, size_t, EntityId const*, view<void*>, Delegate& callback) const;
 
         ComponentId _components[sizeof...(Components)];
         ComponentId _sortedComponents[sizeof...(Components)];
@@ -62,19 +61,14 @@ namespace up {
 
     template <typename... Components>
     template <size_t... Indices>
-    void Query<Components...>::_invokeHelper(std::index_sequence<Indices...>, size_t count, EntityId const* entities, view<void*> arrays, Delegate callback) const {
+    void Query<Components...>::_invoke(std::index_sequence<Indices...>, size_t count, EntityId const* entities, view<void*> arrays, Delegate& callback) const {
         callback(count, entities, static_cast<Components*>(arrays[Indices])...);
-    }
-
-    template <typename... Components>
-    void Query<Components...>::_invoke(size_t count, EntityId const* entities, view<void*> pointers, Delegate callback) const {
-        _invokeHelper(std::make_index_sequence<sizeof...(Components)>(), count, entities, pointers, callback);
     }
 
     template <typename... Components>
     void Query<Components...>::select(World &world, Delegate callback) const {
         world.selectRaw(_sortedComponents, _components, [&, this](size_t count, EntityId const* entities, view<void*> arrays) {
-            this->_invoke(count, entities, arrays, callback);
+            this->_invoke(std::make_index_sequence<sizeof...(Components)>(), count, entities, arrays, callback);
         });
     }
 } // namespace up

--- a/source/library/ecs/public/potato/ecs/world.h
+++ b/source/library/ecs/public/potato/ecs/world.h
@@ -79,7 +79,8 @@ namespace up {
         UP_ECS_API void _addComponentRaw(EntityId entityId, ComponentMeta const* componentMeta, void const* componentData) noexcept;
 
         void _deleteLocation(Location const& location) noexcept;
-        void _calculateLayout(uint32 archetypeIndex, view<ComponentMeta const*> components);
+        void _populateArchetype(uint32 archetypeIndex, view<ComponentMeta const*> components);
+        static void _calculateLayout(Archetype& archetype, size_t size);
         bool _matchArchetype(uint32 archetypeIndex, view<ComponentId> sortedComponents) const noexcept;
         void _selectChunksRaw(uint32 archetypeIndex, view<ComponentId> components, delegate_ref<RawSelectSignature> callback) const;
         void _recycleEntityId(EntityId entity) noexcept;

--- a/source/library/ecs/tests/test_world.cpp
+++ b/source/library/ecs/tests/test_world.cpp
@@ -6,11 +6,11 @@ struct Test1 {
     char a;
 };
 struct Second {
-    char a;
     float b;
+    char a;
 };
 struct Another {
-    float a;
+    double a;
     float b;
 };
 struct Counter {
@@ -29,9 +29,9 @@ DOCTEST_TEST_SUITE("[potato][ecs] World") {
     DOCTEST_TEST_CASE("Archetype selects") {
         World world;
 
-        world.createEntity(Test1{'f'}, Second{'g', 7.f});
-        world.createEntity(Another{1.f, 2.f}, Second{'g', 9.f});
-        world.createEntity(Second{'h', -2.f}, Another{2.f, 1.f});
+        world.createEntity(Test1{'f'}, Second{7.f, 'g'});
+        world.createEntity(Another{1.f, 2.f}, Second{9.f, 'g'});
+        world.createEntity(Second{-2.f, 'h'}, Another{2.f, 1.f});
         world.createEntity(Test1{'j'}, Another{3.f, 4.f});
 
         // Exactly two of the entities should be in the same archetype
@@ -64,9 +64,9 @@ DOCTEST_TEST_SUITE("[potato][ecs] World") {
     DOCTEST_TEST_CASE("Direct component access") {
         World world;
 
-        world.createEntity(Test1{'f'}, Second{'g', 7.f});
-        world.createEntity(Another{1.f, 2.f}, Second{'g', 9.f});
-        auto id = world.createEntity(Second{'h', -2.f}, Another{2.f, 1.f});
+        world.createEntity(Test1{'f'}, Second{7.f, 'g'});
+        world.createEntity(Another{1.f, 2.f}, Second{9.f, 'g'});
+        auto id = world.createEntity(Second{-2.f, 'h'}, Another{2.f, 1.f});
 
         Second* test = world.getComponentSlow<Second>(id);
         DOCTEST_CHECK(test != nullptr);
@@ -77,8 +77,8 @@ DOCTEST_TEST_SUITE("[potato][ecs] World") {
     DOCTEST_TEST_CASE("EntityId management") {
         World world;
 
-        EntityId first = world.createEntity(Test1{'f'}, Second{'g', 7.f});
-        EntityId second = world.createEntity(Test1{'h'}, Second{'i', -1.f});
+        EntityId first = world.createEntity(Test1{'f'}, Second{7.f, 'g'});
+        EntityId second = world.createEntity(Test1{'h'}, Second{-1.f, 'i'});
 
         Query<Test1> query;
         query.select(world, ([&](size_t count, EntityId const* ids, Test1*) {


### PR DESCRIPTION
Component array index was used for layout array, even though the latter is sorted and the indices no longer match.

Split the code into a separate function to make that kind of error harder.