### PR TITLE
UUID style updates

### DIFF
--- a/source/librecon/private/converter_app.cpp
+++ b/source/librecon/private/converter_app.cpp
@@ -292,7 +292,7 @@ auto up::recon::ConverterApp::checkMetafile(Context& ctx, string_view filename) 
         Converter* conveter = findConverter(filename);
         if (conveter) {
             nlohmann::json root;
-            string id = UUID::toString(UUID::generate());
+            string id = UUID::generate().toString();
             root["id"] = id.c_str();
 
             Context context(filename.data(), _config.sourceFolderPath.c_str(), _config.destinationFolderPath.c_str(), *_fileSystem, _logger);

--- a/source/librecon/private/converter_app.cpp
+++ b/source/librecon/private/converter_app.cpp
@@ -292,7 +292,7 @@ auto up::recon::ConverterApp::checkMetafile(Context& ctx, string_view filename) 
         Converter* conveter = findConverter(filename);
         if (conveter) {
             nlohmann::json root;
-            string id = uuid::toString(uuid::generate());
+            string id = UUID::toString(UUID::generate());
             root["id"] = id.c_str();
 
             Context context(filename.data(), _config.sourceFolderPath.c_str(), _config.destinationFolderPath.c_str(), *_fileSystem, _logger);

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -15,15 +15,15 @@ constexpr char byteToString(up::byte byte) noexcept {
     return static_cast<char>(byte);
 }
 
-auto up::UUID::toString(const UUID& id) -> string {
+auto up::UUID::toString() const -> string {
     // format 9554084e-4100-4098-b470-2125f5eed133
     string_writer buffer;
     format_into(buffer, "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-                id._data.ub[0], id._data.ub[1], id._data.ub[2], id._data.ub[3],
-                id._data.ub[4], id._data.ub[5],
-                id._data.ub[6], id._data.ub[7],
-                id._data.ub[8], id._data.ub[9],
-                id._data.ub[10], id._data.ub[11], id._data.ub[12], id._data.ub[13], id._data.ub[14], id._data.ub[15]);
+                _data.ub[0], _data.ub[1], _data.ub[2], _data.ub[3],
+                _data.ub[4], _data.ub[5],
+                _data.ub[6], _data.ub[7],
+                _data.ub[8], _data.ub[9],
+                _data.ub[10], _data.ub[11], _data.ub[12], _data.ub[13], _data.ub[14], _data.ub[15]);
 
     return buffer.c_str();
 }

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -50,7 +50,7 @@ auto up::UUID::fromString(string_view id) noexcept -> UUID {
         }
 
         next <<= 4;
-        next |= byte{digit};
+        next |= static_cast<byte>(digit);
 
         if (octect) {
             if (bidx == 16) {

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -4,7 +4,7 @@
 #include "potato/runtime/assertion.h"
 #include "potato/spud/string_writer.h"
 
-up::uuid::uuid(up::byte const (&bytes)[16]) noexcept : _data{HighLow{}} {
+up::UUID::UUID(up::byte const (&bytes)[16]) noexcept : _data{HighLow{}} {
     for (int i = 0; i != 16; ++i) {
         _data.ub[i] = bytes[i];
     }
@@ -14,7 +14,7 @@ constexpr char byteToString(up::byte byte) noexcept {
     return static_cast<char>(byte);
 }
 
-auto up::uuid::toString(const uuid& id) -> string {
+auto up::UUID::toString(const UUID& id) -> string {
     // format 9554084e-4100-4098-b470-2125f5eed133
     string_writer buffer;
     format_into(buffer, "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
@@ -56,22 +56,22 @@ static auto hexDigitToChar(char c) -> unsigned char {
     return 0;
 }
 
-auto up::uuid::fromString(string_view id) noexcept -> uuid {
+auto up::UUID::fromString(string_view id) noexcept -> UUID {
     auto len = id.size();
     if (len != 36)
-        return uuid::zero();
+        return UUID::zero();
 
     char buffer[2]; // reading 2 chars at a time
     uint32 chidx = 0;
 
-    uuid result;
+    UUID result;
     uint32 bidx = 0;
     for (auto c : id) {
         if (c == '-')
             continue;
 
         if (!isValidChar(c))
-            return uuid::zero();
+            return UUID::zero();
 
         buffer[chidx++] = c;
 

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -80,6 +80,12 @@ auto up::UUID::fromString(string_view id) noexcept -> UUID {
             chidx = 0;
             result._data.ub[bidx++] = v;
         }
+
+        octect = !octect;
+    }
+
+    if (bidx != 16 || octect) {
+        return zero();
     }
 
     return result;

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -46,7 +46,7 @@ auto up::UUID::fromString(string_view id) noexcept -> UUID {
 
         int digit = ascii::from_hex(c);
         if (digit == -1) {
-            return UUID::zero();
+            return UUID{};
         }
 
         next <<= 4;
@@ -54,7 +54,7 @@ auto up::UUID::fromString(string_view id) noexcept -> UUID {
 
         if (octect) {
             if (bidx == 16) {
-                return zero();
+                return UUID{};
             }
             result._data.ub[bidx++] = next;
         }
@@ -63,7 +63,7 @@ auto up::UUID::fromString(string_view id) noexcept -> UUID {
     }
 
     if (bidx != 16 || octect) {
-        return zero();
+        return UUID{};
     }
 
     return result;

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -29,6 +29,10 @@ auto up::UUID::toString(const UUID& id) -> string {
 }
 
 auto up::UUID::fromString(string_view id) noexcept -> UUID {
+    if (!id.empty() && id.front() == '{' && id.back() == '}') {
+        id = id.substr(1, id.size() - 2);
+    }
+
     byte next = {};
     bool octect = false;
 

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -4,49 +4,25 @@
 #include "potato/runtime/assertion.h"
 #include "potato/spud/string_writer.h"
 
-using namespace up;
-
-
-uuid::uuid() noexcept {
-    std::memset(&_data, 0, sizeof(_data));
-}
-
-uuid::uuid(const uuid& other) noexcept {
-    if (this == &other)
-        return;
-    std::memcpy(&_data, &other._data, sizeof(_data));
-}
-
-uuid::uuid(const buffer& value) noexcept {
-    std::memcpy(_data.data(), value.data(), sizeof(_data));
-}
-
-auto uuid::isValid() noexcept -> bool {
-    return *this != uuid::zero();
-}
-
-uuid uuid::generate() noexcept {
-    return uuid(_generate());
-}
-
-uuid uuid::zero() noexcept {
-    static uuid _zero(uuid::buffer({}));
-    return _zero;
+up::uuid::uuid(up::byte const (&bytes)[16]) noexcept : _data{HighLow{}} {
+    for (int i = 0; i != 16; ++i) {
+        _data.ub[i] = bytes[i];
+    }
 }
 
 constexpr char byteToString(up::byte byte) noexcept {
     return static_cast<char>(byte);
 }
 
-string uuid::toString(const uuid& id) {
+auto up::uuid::toString(const uuid& id) -> string {
     // format 9554084e-4100-4098-b470-2125f5eed133
     string_writer buffer;
     format_into(buffer, "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-                id._data[0], id._data[1], id._data[2], id._data[3],
-                id._data[4], id._data[5],
-                id._data[6], id._data[7],
-                id._data[8], id._data[9],
-                id._data[10], id._data[11], id._data[12], id._data[13], id._data[14], id._data[15]);
+                id._data.ub[0], id._data.ub[1], id._data.ub[2], id._data.ub[3],
+                id._data.ub[4], id._data.ub[5],
+                id._data.ub[6], id._data.ub[7],
+                id._data.ub[8], id._data.ub[9],
+                id._data.ub[10], id._data.ub[11], id._data.ub[12], id._data.ub[13], id._data.ub[14], id._data.ub[15]);
 
     return buffer.c_str();
 }
@@ -80,7 +56,7 @@ static auto hexDigitToChar(char c) -> unsigned char {
     return 0;
 }
 
-uuid uuid::fromString(string_view id) noexcept {
+auto up::uuid::fromString(string_view id) noexcept -> uuid {
     auto len = id.size();
     if (len != 36)
         return uuid::zero();
@@ -102,7 +78,7 @@ uuid uuid::fromString(string_view id) noexcept {
         if (chidx == 2) {
             byte v = static_cast<byte>(hexDigitToChar(buffer[0]) * 16 + hexDigitToChar(buffer[1]));
             chidx = 0;
-            result._data[bidx++] = v;
+            result._data.ub[bidx++] = v;
         }
     }
 

--- a/source/libruntime/private/uuid.darwin.cpp
+++ b/source/libruntime/private/uuid.darwin.cpp
@@ -8,12 +8,12 @@
 #    error "Unsupported platform"
 #endif
 
-auto up::uuid::generate() noexcept -> uuid {
+auto up::UUID::generate() noexcept -> UUID {
     auto newId = CFUUIDCreate(NULL);
     auto bytes = CFUUIDGetUUIDBytes(newId);
     CFRelease(newId);
 
-    uuid ret;
+    UUID ret;
     static_assert(sizeof(ret) == sizeof(bytes));
     std::memcpy(ret.data(), &bytes, sizeof(bytes));
     return ret;

--- a/source/libruntime/private/uuid.darwin.cpp
+++ b/source/libruntime/private/uuid.darwin.cpp
@@ -8,13 +8,12 @@
 #    error "Unsupported platform"
 #endif
 
-auto up::uuid::_generate() noexcept -> uuid::buffer {
-
+auto up::uuid::generate() noexcept -> uuid {
     auto newId = CFUUIDCreate(NULL);
     auto bytes = CFUUIDGetUUIDBytes(newId);
     CFRelease(newId);
 
-    uuid::buffer ret;
+    uuid ret;
     static_assert(sizeof(ret) == sizeof(bytes));
     std::memcpy(ret.data(), &bytes, sizeof(bytes));
     return ret;

--- a/source/libruntime/private/uuid.darwin.cpp
+++ b/source/libruntime/private/uuid.darwin.cpp
@@ -15,6 +15,6 @@ auto up::UUID::generate() noexcept -> UUID {
 
     UUID ret;
     static_assert(sizeof(ret) == sizeof(bytes));
-    std::memcpy(ret.data(), &bytes, sizeof(bytes));
+    std::memcpy(ret._data.ub, &bytes, sizeof(bytes));
     return ret;
 }

--- a/source/libruntime/private/uuid.linux.cpp
+++ b/source/libruntime/private/uuid.linux.cpp
@@ -9,7 +9,11 @@
 #endif
 
 auto up::UUID::generate() noexcept -> UUID {
+    uuid_t temp;
+    uuid_generate(temp);
+
     UUID ret;
-    uuid_generate(static_cast<char*>(ret._data.ub));
+    static_assert(sizeof(ret) == sizeof(temp));
+    std::memcpy(ret._data.ub, &temp, sizeof(ret));
     return ret;
 }

--- a/source/libruntime/private/uuid.linux.cpp
+++ b/source/libruntime/private/uuid.linux.cpp
@@ -8,8 +8,8 @@
 #    error "Unsupported platform"
 #endif
 
-auto up::uuid::generate() noexcept -> uuid {
-    uuid ret;
+auto up::UUID::generate() noexcept -> UUID {
+    UUID ret;
     uuid_generate(static_cast<char*>(ret._data.ub));
     return ret;
 }

--- a/source/libruntime/private/uuid.linux.cpp
+++ b/source/libruntime/private/uuid.linux.cpp
@@ -8,8 +8,8 @@
 #    error "Unsupported platform"
 #endif
 
-auto up::uuid::_generate() noexcept -> uuid::buffer {
-    uuid::buffer ret;
-    uuid_generate((unsigned char*)ret.data());
+auto up::uuid::generate() noexcept -> uuid {
+    uuid ret;
+    uuid_generate(static_cast<char*>(ret._data.ub));
     return ret;
 }

--- a/source/libruntime/private/uuid.windows.cpp
+++ b/source/libruntime/private/uuid.windows.cpp
@@ -9,14 +9,14 @@
 #    error "Unsupported platform"
 #endif
 
-auto up::uuid::_generate() noexcept -> uuid::buffer {
+auto up::uuid::generate() noexcept -> uuid {
     UUID temp;
     if (RPC_S_OK != UuidCreate(&temp)) {
         UP_ASSERT(false, "Failed to generate unique ID.");
     }
 
-    uuid::buffer ret;
+    uuid ret;
     static_assert(sizeof(ret) == sizeof(UUID));
-    std::memcpy(ret.data(), &temp, sizeof(UUID));
+    std::memcpy(ret._data.ub, &temp, sizeof(UUID));
     return ret;
 }

--- a/source/libruntime/private/uuid.windows.cpp
+++ b/source/libruntime/private/uuid.windows.cpp
@@ -9,13 +9,13 @@
 #    error "Unsupported platform"
 #endif
 
-auto up::uuid::generate() noexcept -> uuid {
-    UUID temp;
+auto up::UUID::generate() noexcept -> UUID {
+    ::GUID temp;
     if (RPC_S_OK != UuidCreate(&temp)) {
         UP_ASSERT(false, "Failed to generate unique ID.");
     }
 
-    uuid ret;
+    UUID ret;
     static_assert(sizeof(ret) == sizeof(UUID));
     std::memcpy(ret._data.ub, &temp, sizeof(UUID));
     return ret;

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -8,26 +8,26 @@
 
 namespace up {
 
-    class UP_RUNTIME_API uuid {
+    class UP_RUNTIME_API UUID {
     public:
-        constexpr uuid() noexcept : _data{HighLow{}} {}
-        constexpr uuid(uuid const& rhs) noexcept : _data{rhs._data.u64} {}
-        uuid(up::byte const (&bytes)[16]) noexcept;
+        constexpr UUID() noexcept : _data{HighLow{}} {}
+        constexpr UUID(UUID const& rhs) noexcept : _data{rhs._data.u64} {}
+        UUID(up::byte const (&bytes)[16]) noexcept;
 
         constexpr bool isValid() noexcept { return _data.u64.high != 0 && _data.u64.low != 0; }
 
-        constexpr bool operator==(uuid const& rhs) const noexcept {
+        constexpr bool operator==(UUID const& rhs) const noexcept {
             return _data.u64.high == rhs._data.u64.high && _data.u64.low == rhs._data.u64.low;
         }
-        constexpr bool operator!=(uuid const& rhs) const noexcept {
+        constexpr bool operator!=(UUID const& rhs) const noexcept {
             return _data.u64.high != rhs._data.u64.high || _data.u64.low != rhs._data.u64.low;
         }
 
-        static auto generate() noexcept -> uuid;
-        static auto toString(const uuid& id) -> string;
-        static auto fromString(string_view id) noexcept -> uuid;
+        static auto generate() noexcept -> UUID;
+        static auto toString(const UUID& id) -> string;
+        static auto fromString(string_view id) noexcept -> UUID;
 
-        static constexpr uuid zero() noexcept { return uuid{}; }
+        static constexpr UUID zero() noexcept { return UUID{}; }
 
     private:
         struct HighLow {
@@ -43,6 +43,6 @@ namespace up {
         Storage _data;
     };
 
-    static_assert(sizeof(uuid) == 16, "sizeof(uuid) must be 16 octects");
+    static_assert(sizeof(UUID) == 16, "sizeof(uuid) must be 16 octects");
 
 } // namespace up

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -10,27 +10,39 @@ namespace up {
 
     class UP_RUNTIME_API uuid {
     public:
-        using buffer = std::array<up::byte, 16>;
+        constexpr uuid() noexcept : _data{HighLow{}} {}
+        constexpr uuid(uuid const& rhs) noexcept : _data{rhs._data.u64} {}
+        uuid(up::byte const (&bytes)[16]) noexcept;
 
-        uuid() noexcept;
-        uuid(const uuid& other) noexcept;
-        uuid(const buffer& value) noexcept;
+        constexpr bool isValid() noexcept { return _data.u64.high != 0 && _data.u64.low != 0; }
 
-        bool isValid() noexcept;
+        constexpr bool operator==(uuid const& rhs) const noexcept {
+            return _data.u64.high == rhs._data.u64.high && _data.u64.low == rhs._data.u64.low;
+        }
+        constexpr bool operator!=(uuid const& rhs) const noexcept {
+            return _data.u64.high != rhs._data.u64.high || _data.u64.low != rhs._data.u64.low;
+        }
 
-        bool operator==(const uuid& other) const noexcept { return _data == other._data; }
-        bool operator!=(const uuid& other) const noexcept { return !operator==(other); }
+        static auto generate() noexcept -> uuid;
+        static auto toString(const uuid& id) -> string;
+        static auto fromString(string_view id) noexcept -> uuid;
 
-        static uuid generate() noexcept;
-        static string toString(const uuid& id);
-        static uuid fromString(string_view id) noexcept;
-
-        static uuid zero() noexcept;
+        static constexpr uuid zero() noexcept { return uuid{}; }
 
     private:
-        static auto _generate() noexcept -> buffer;
+        struct HighLow {
+            uint64 high = 0;
+            uint64 low = 0;
+        };
 
-        buffer _data;
+        union Storage {
+            HighLow u64;
+            byte ub[16];
+        };
+
+        Storage _data;
     };
+
+    static_assert(sizeof(uuid) == 16, "sizeof(uuid) must be 16 octects");
 
 } // namespace up

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -14,7 +14,7 @@ namespace up {
         constexpr UUID(UUID const& rhs) noexcept : _data{rhs._data.u64} {}
         UUID(up::byte const (&bytes)[16]) noexcept;
 
-        constexpr bool isValid() noexcept { return _data.u64.high != 0 && _data.u64.low != 0; }
+        constexpr bool isValid() const noexcept { return _data.u64.high != 0 || _data.u64.low != 0; }
 
         constexpr bool operator==(UUID const& rhs) const noexcept {
             return _data.u64.high == rhs._data.u64.high && _data.u64.low == rhs._data.u64.low;

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -27,8 +27,6 @@ namespace up {
         static auto toString(const UUID& id) -> string;
         static auto fromString(string_view id) noexcept -> UUID;
 
-        static constexpr UUID zero() noexcept { return UUID{}; }
-
     private:
         struct HighLow {
             uint64 high = 0;

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -23,8 +23,9 @@ namespace up {
             return _data.u64.high != rhs._data.u64.high || _data.u64.low != rhs._data.u64.low;
         }
 
+        auto toString() const -> string;
+
         static auto generate() noexcept -> UUID;
-        static auto toString(const UUID& id) -> string;
         static auto fromString(string_view id) noexcept -> UUID;
 
     private:

--- a/source/libruntime/tests/test_uuid.cpp
+++ b/source/libruntime/tests/test_uuid.cpp
@@ -2,33 +2,33 @@
 #include <doctest/doctest.h>
 #include <array>
 
-DOCTEST_TEST_SUITE("[potato][runtime] up::uuid") {
+DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
     using namespace up;
 
     DOCTEST_TEST_CASE("basic uuid") {
-        uuid zero = uuid();
-        DOCTEST_CHECK(zero == uuid::zero());
-        DOCTEST_CHECK_EQ(uuid::toString(zero).c_str(), "00000000-0000-0000-0000-000000000000");
+        UUID zero = UUID();
+        DOCTEST_CHECK(zero == UUID::zero());
+        DOCTEST_CHECK_EQ(UUID::toString(zero).c_str(), "00000000-0000-0000-0000-000000000000");
 
-        uuid a = uuid::generate();
+        UUID a = UUID::generate();
         DOCTEST_CHECK(a.isValid());
 
-        string str = uuid::toString(a);
-        uuid b = uuid::fromString(str);
+        string str = UUID::toString(a);
+        UUID b = UUID::fromString(str);
         DOCTEST_CHECK(b == a);
 
-        const uuid c = uuid::fromString("00000000-0000-0000-0000-000000000000");
-        DOCTEST_CHECK(c == uuid::zero());
+        const UUID c = UUID::fromString("00000000-0000-0000-0000-000000000000");
+        DOCTEST_CHECK(c == UUID::zero());
 
         // check invalid length of string
-        const uuid d = uuid::fromString("9554084e-4100-4098-b470-2125f5eed13");
-        DOCTEST_CHECK(d == uuid::zero());
-        const uuid e = uuid::fromString("9554084e-4100-4098-b470-2125f5eed133f");
-        DOCTEST_CHECK(e == uuid::zero());
-        const uuid f = uuid::fromString("955408-4e4100-4098-b470-2125f5eed133f");
-        DOCTEST_CHECK(f == uuid::zero());
-        const uuid g = uuid::fromString("9554084e-41K0-4098-PODR-25f5eed133fN");
-        DOCTEST_CHECK(g == uuid::zero());
+        const UUID d = UUID::fromString("9554084e-4100-4098-b470-2125f5eed13");
+        DOCTEST_CHECK(d == UUID::zero());
+        const UUID e = UUID::fromString("9554084e-4100-4098-b470-2125f5eed133f");
+        DOCTEST_CHECK(e == UUID::zero());
+        const UUID f = UUID::fromString("955408-4e4100-4098-b470-2125f5eed133f");
+        DOCTEST_CHECK(f == UUID::zero());
+        const UUID g = UUID::fromString("9554084e-41K0-4098-PODR-25f5eed133fN");
+        DOCTEST_CHECK(g == UUID::zero());
 
     }
 }

--- a/source/libruntime/tests/test_uuid.cpp
+++ b/source/libruntime/tests/test_uuid.cpp
@@ -15,20 +15,22 @@ DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
 
         string str = UUID::toString(a);
         UUID b = UUID::fromString(str);
-        DOCTEST_CHECK(b == a);
+        DOCTEST_CHECK_EQ(b, a);
 
         const UUID c = UUID::fromString("00000000-0000-0000-0000-000000000000");
-        DOCTEST_CHECK(c == UUID::zero());
+        DOCTEST_CHECK_EQ(c, UUID::zero());
 
         // check invalid length of string
         const UUID d = UUID::fromString("9554084e-4100-4098-b470-2125f5eed13");
-        DOCTEST_CHECK(d == UUID::zero());
+        DOCTEST_CHECK_EQ(d, UUID::zero());
         const UUID e = UUID::fromString("9554084e-4100-4098-b470-2125f5eed133f");
-        DOCTEST_CHECK(e == UUID::zero());
+        DOCTEST_CHECK_EQ(e, UUID::zero());
         const UUID f = UUID::fromString("955408-4e4100-4098-b470-2125f5eed133f");
-        DOCTEST_CHECK(f == UUID::zero());
+        DOCTEST_CHECK_EQ(f, UUID::zero());
         const UUID g = UUID::fromString("9554084e-41K0-4098-PODR-25f5eed133fN");
-        DOCTEST_CHECK(g == UUID::zero());
+        DOCTEST_CHECK_EQ(g, UUID::zero());
 
+        const UUID h = UUID::fromString("{10000000-0000-0000-0000-000000000002}");
+        DOCTEST_CHECK(h.isValid());
     }
 }

--- a/source/libruntime/tests/test_uuid.cpp
+++ b/source/libruntime/tests/test_uuid.cpp
@@ -32,5 +32,10 @@ DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
 
         const UUID h = UUID::fromString("{10000000-0000-0000-0000-000000000002}");
         DOCTEST_CHECK(h.isValid());
+
+        string_view const input = "9554084e-4100-4098-b470-2125f5eed133";
+        const UUID i = UUID::fromString(input);
+        string const output = UUID::toString(i);
+        DOCTEST_CHECK_EQ(static_cast<string_view>(output), input);
     }
 }

--- a/source/libruntime/tests/test_uuid.cpp
+++ b/source/libruntime/tests/test_uuid.cpp
@@ -7,8 +7,8 @@ DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
 
     DOCTEST_TEST_CASE("basic uuid") {
         UUID zero = UUID();
-        DOCTEST_CHECK(zero == UUID::zero());
         DOCTEST_CHECK_EQ(UUID::toString(zero).c_str(), "00000000-0000-0000-0000-000000000000");
+        DOCTEST_CHECK(zero == UUID{});
 
         UUID a = UUID::generate();
         DOCTEST_CHECK(a.isValid());
@@ -18,17 +18,17 @@ DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
         DOCTEST_CHECK_EQ(b, a);
 
         const UUID c = UUID::fromString("00000000-0000-0000-0000-000000000000");
-        DOCTEST_CHECK_EQ(c, UUID::zero());
+        DOCTEST_CHECK_EQ(c, UUID{});
 
         // check invalid length of string
         const UUID d = UUID::fromString("9554084e-4100-4098-b470-2125f5eed13");
-        DOCTEST_CHECK_EQ(d, UUID::zero());
+        DOCTEST_CHECK_EQ(d, UUID{});
         const UUID e = UUID::fromString("9554084e-4100-4098-b470-2125f5eed133f");
-        DOCTEST_CHECK_EQ(e, UUID::zero());
+        DOCTEST_CHECK_EQ(e, UUID{});
         const UUID f = UUID::fromString("955408-4e4100-4098-b470-2125f5eed133f");
-        DOCTEST_CHECK_EQ(f, UUID::zero());
+        DOCTEST_CHECK_EQ(f, UUID{});
         const UUID g = UUID::fromString("9554084e-41K0-4098-PODR-25f5eed133fN");
-        DOCTEST_CHECK_EQ(g, UUID::zero());
+        DOCTEST_CHECK_EQ(g, UUID{});
 
         const UUID h = UUID::fromString("{10000000-0000-0000-0000-000000000002}");
         DOCTEST_CHECK(h.isValid());

--- a/source/libruntime/tests/test_uuid.cpp
+++ b/source/libruntime/tests/test_uuid.cpp
@@ -7,13 +7,13 @@ DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
 
     DOCTEST_TEST_CASE("basic uuid") {
         UUID zero = UUID();
-        DOCTEST_CHECK_EQ(UUID::toString(zero).c_str(), "00000000-0000-0000-0000-000000000000");
         DOCTEST_CHECK(zero == UUID{});
+        DOCTEST_CHECK_EQ(zero.toString().c_str(), "00000000-0000-0000-0000-000000000000");
 
         UUID a = UUID::generate();
         DOCTEST_CHECK(a.isValid());
 
-        string str = UUID::toString(a);
+        string str = a.toString();
         UUID b = UUID::fromString(str);
         DOCTEST_CHECK_EQ(b, a);
 
@@ -35,7 +35,7 @@ DOCTEST_TEST_SUITE("[potato][runtime] up::UUID") {
 
         string_view const input = "9554084e-4100-4098-b470-2125f5eed133";
         const UUID i = UUID::fromString(input);
-        string const output = UUID::toString(i);
+        string const output = i.toString();
         DOCTEST_CHECK_EQ(static_cast<string_view>(output), input);
     }
 }

--- a/source/spud/public/potato/spud/CMakeLists.txt
+++ b/source/spud/public/potato/spud/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(potato_spud PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/_assertion.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/ascii.h
     ${CMAKE_CURRENT_SOURCE_DIR}/box.h
     ${CMAKE_CURRENT_SOURCE_DIR}/const_util.h
     ${CMAKE_CURRENT_SOURCE_DIR}/delegate.h

--- a/source/spud/public/potato/spud/ascii.h
+++ b/source/spud/public/potato/spud/ascii.h
@@ -1,0 +1,37 @@
+// Copyright (C) 2019 Marcin Wieczorek, Sean Middleditch, all rights reserverd.
+
+namespace up::ascii {
+    constexpr auto is_digit(char const ch) noexcept -> bool {
+        return ch >= '0' && ch <= '9';
+    }
+
+    constexpr auto is_alpha(char const ch) noexcept -> bool {
+        return (ch >= 'a' && ch <= 'z') ||
+               (ch >= 'A' && ch <= 'A');
+    }
+
+    constexpr auto is_alnum(char const ch) noexcept -> bool {
+        return is_digit(ch) || is_alpha(ch);
+    }
+
+    constexpr auto is_hex_digit(char const ch) noexcept -> bool {
+        return is_digit(ch) ||
+               (ch >= 'a' && ch <= 'f') ||
+               (ch >= 'A' && ch <= 'F');
+    }
+
+    constexpr auto from_hex(char const ch) noexcept -> int {
+        if (ch >= '0' && ch <= '9') {
+            return ch - '0';
+        }
+        else if (ch >= 'a' && ch <= 'f') {
+            return ch - 'a' + 10;
+        }
+        else if (ch >= 'A' && ch <= 'F') {
+            return ch - 'A' + 10;
+        }
+        else {
+            return -1;
+        }
+    }
+} // namespace up::ascii


### PR DESCRIPTION
Same functionality. New fancy style.

- Got rid of `using namespace up` since that will cause pain with blob builds.
- Normalized style to rest of code.
- Renamed to `UUID` since it's not in spud (stl replacement) anymore.
- Removed redundant `zero()` static function.
- Made `toString()` a non-static member function.
- Added support to parse `{ABCD-...-XYWZ}` style guids.
- Split platform code into separate per-platform files.
- Made it `constexpr`-friendly; required some rejiggering of storage and removal of `memcpy` in common cases.