### PR TITLE
Copyright cleanup

### DIFF
--- a/documentation/coding-style.md
+++ b/documentation/coding-style.md
@@ -1,6 +1,21 @@
 Coding Style
 ============
 
+EditorConfig and ClangFormat
+----------------------------
+
+The `.editorconfig` and `clang-format` tools are used to enforce style guides. Ensure support for these is enabled in your editor for the smoothest experience.
+
+File Header
+-----------
+
+Every file should contain the following copyright header:
+
+```c++
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+```
+
 Spacing and Indentation
 -----------------------
 

--- a/source/bin_recon/private/main.cpp
+++ b/source/bin_recon/private/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/recon/converter_app.h"
 #include <iostream>

--- a/source/bin_shell/private/camera.cpp
+++ b/source/bin_shell/private/camera.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "camera.h"
 #include <glm/gtx/rotate_vector.hpp>

--- a/source/bin_shell/private/camera.h
+++ b/source/bin_shell/private/camera.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/bin_shell/private/camera_controller.cpp
+++ b/source/bin_shell/private/camera_controller.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "camera_controller.h"
 #include "camera.h"

--- a/source/bin_shell/private/camera_controller.h
+++ b/source/bin_shell/private/camera_controller.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <glm/vec3.hpp>
 #include <glm/gtc/constants.hpp>

--- a/source/bin_shell/private/components.h
+++ b/source/bin_shell/private/components.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019,2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/ecs/component.h>
 #include <potato/render/model.h>

--- a/source/bin_shell/private/game_panel.cpp
+++ b/source/bin_shell/private/game_panel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <glm/glm.hpp>
 #include <imgui.h>

--- a/source/bin_shell/private/hierarchy_panel.cpp
+++ b/source/bin_shell/private/hierarchy_panel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <imgui.h>
 #include <SDL.h>

--- a/source/bin_shell/private/imgui_reflector.cpp
+++ b/source/bin_shell/private/imgui_reflector.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "imgui_reflector.h"
 

--- a/source/bin_shell/private/imgui_reflector.h
+++ b/source/bin_shell/private/imgui_reflector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/ecs/reflector.h>
 

--- a/source/bin_shell/private/inspector_panel.cpp
+++ b/source/bin_shell/private/inspector_panel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <glm/glm.hpp>
 #include <imgui.h>

--- a/source/bin_shell/private/main.cpp
+++ b/source/bin_shell/private/main.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "shell_app.h"
 

--- a/source/bin_shell/private/scene.cpp
+++ b/source/bin_shell/private/scene.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "scene.h"
 #include "components.h"

--- a/source/bin_shell/private/scene.h
+++ b/source/bin_shell/private/scene.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/spud/box.h>
 #include <potato/spud/rc.h>

--- a/source/bin_shell/private/scene_panel.cpp
+++ b/source/bin_shell/private/scene_panel.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <glm/glm.hpp>
 #include <imgui.h>

--- a/source/bin_shell/private/shell_app.cpp
+++ b/source/bin_shell/private/shell_app.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "shell_app.h"
 #include "camera.h"

--- a/source/bin_shell/private/shell_app.h
+++ b/source/bin_shell/private/shell_app.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "camera.h"
 

--- a/source/bin_shell/public/potato/shell/panel.h
+++ b/source/bin_shell/public/potato/shell/panel.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/spud/zstring_view.h>
 

--- a/source/bin_shell/public/potato/shell/selection.h
+++ b/source/bin_shell/public/potato/shell/selection.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/ecs/common.h>
 

--- a/source/libassetdb/private/asset_library.cpp
+++ b/source/libassetdb/private/asset_library.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/assetdb/_export.h"
 #include "potato/assetdb/asset_library.h"

--- a/source/libassetdb/private/asset_record.cpp
+++ b/source/libassetdb/private/asset_record.cpp
@@ -1,5 +1,5 @@
 
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/runtime/assertion.h>
 #include "potato/assetdb/asset_record.h"

--- a/source/libassetdb/private/hash_cache.cpp
+++ b/source/libassetdb/private/hash_cache.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/assetdb/hash_cache.h"
 #include "potato/spud/hash_fnv1a.h"

--- a/source/libassetdb/public/potato/assetdb/_export.h
+++ b/source/libassetdb/public/potato/assetdb/_export.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libassetdb/public/potato/assetdb/asset_library.h
+++ b/source/libassetdb/public/potato/assetdb/asset_library.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libassetdb/public/potato/assetdb/asset_record.h
+++ b/source/libassetdb/public/potato/assetdb/asset_record.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libassetdb/public/potato/assetdb/common.h
+++ b/source/libassetdb/public/potato/assetdb/common.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libassetdb/public/potato/assetdb/hash_cache.h
+++ b/source/libassetdb/public/potato/assetdb/hash_cache.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/private/entity_id.h
+++ b/source/libecs/private/entity_id.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/private/shared_context.cpp
+++ b/source/libecs/private/shared_context.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/ecs/shared_context.h"
 #include <potato/spud/find.h>

--- a/source/libecs/private/universe.cpp
+++ b/source/libecs/private/universe.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/ecs/shared_context.h"
 #include "potato/ecs/universe.h"

--- a/source/libecs/private/world.cpp
+++ b/source/libecs/private/world.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/ecs/world.h"
 #include "entity_id.h"

--- a/source/libecs/public/potato/ecs/_export.h
+++ b/source/libecs/public/potato/ecs/_export.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/chunk.h
+++ b/source/libecs/public/potato/ecs/chunk.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/common.h
+++ b/source/libecs/public/potato/ecs/common.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/component.h
+++ b/source/libecs/public/potato/ecs/component.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/layout.h
+++ b/source/libecs/public/potato/ecs/layout.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/query.h
+++ b/source/libecs/public/potato/ecs/query.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/reflector.h
+++ b/source/libecs/public/potato/ecs/reflector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/shared_context.h
+++ b/source/libecs/public/potato/ecs/shared_context.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/universe.h
+++ b/source/libecs/public/potato/ecs/universe.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libecs/public/potato/ecs/world.h
+++ b/source/libecs/public/potato/ecs/world.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/append_writer.h
+++ b/source/libformat/public/potato/format/_detail/append_writer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/fixed_writer.h
+++ b/source/libformat/public/potato/format/_detail/fixed_writer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/format_arg.h
+++ b/source/libformat/public/potato/format/_detail/format_arg.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/format_arg_impl.h
+++ b/source/libformat/public/potato/format/_detail/format_arg_impl.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/format_impl.h
+++ b/source/libformat/public/potato/format/_detail/format_impl.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/format_result.h
+++ b/source/libformat/public/potato/format/_detail/format_result.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/format_spec.h
+++ b/source/libformat/public/potato/format/_detail/format_spec.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/format_traits.h
+++ b/source/libformat/public/potato/format/_detail/format_traits.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/parse_unsigned.h
+++ b/source/libformat/public/potato/format/_detail/parse_unsigned.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/write_float.h
+++ b/source/libformat/public/potato/format/_detail/write_float.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/write_integer.h
+++ b/source/libformat/public/potato/format/_detail/write_integer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/_detail/write_string.h
+++ b/source/libformat/public/potato/format/_detail/write_string.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/format.h
+++ b/source/libformat/public/potato/format/format.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libformat/public/potato/format/std_string.h
+++ b/source/libformat/public/potato/format/std_string.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2020 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/private/context.cpp
+++ b/source/librecon/private/context.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/recon/context.h"
 

--- a/source/librecon/private/converter_app.cpp
+++ b/source/librecon/private/converter_app.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/recon/converter_app.h"
 #include "potato/spud/string_view.h"

--- a/source/librecon/private/converter_config.cpp
+++ b/source/librecon/private/converter_config.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/recon/converter_config.h"
 #include "potato/spud/string_view.h"

--- a/source/librecon/private/converters/convert_copy.cpp
+++ b/source/librecon/private/converters/convert_copy.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "convert_copy.h"
 #include "potato/spud/std_iostream.h"

--- a/source/librecon/private/converters/convert_copy.h
+++ b/source/librecon/private/converters/convert_copy.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/private/converters/convert_hlsl.cpp
+++ b/source/librecon/private/converters/convert_hlsl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "convert_hlsl.h"
 #include "potato/runtime/com_ptr.h"

--- a/source/librecon/private/converters/convert_hlsl.h
+++ b/source/librecon/private/converters/convert_hlsl.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/private/converters/convert_ignore.h
+++ b/source/librecon/private/converters/convert_ignore.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/private/converters/convert_json.cpp
+++ b/source/librecon/private/converters/convert_json.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "convert_json.h"
 #include "potato/spud/std_iostream.h"

--- a/source/librecon/private/converters/convert_json.h
+++ b/source/librecon/private/converters/convert_json.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/private/converters/convert_material.cpp
+++ b/source/librecon/private/converters/convert_material.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "convert_material.h"
 #include "potato/spud/std_iostream.h"

--- a/source/librecon/private/converters/convert_material.h
+++ b/source/librecon/private/converters/convert_material.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/private/converters/convert_model.cpp
+++ b/source/librecon/private/converters/convert_model.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "convert_model.h"
 #include "potato/spud/std_iostream.h"

--- a/source/librecon/private/converters/convert_model.h
+++ b/source/librecon/private/converters/convert_model.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/public/potato/recon/context.h
+++ b/source/librecon/public/potato/recon/context.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/public/potato/recon/converter.h
+++ b/source/librecon/public/potato/recon/converter.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/public/potato/recon/converter_app.h
+++ b/source/librecon/public/potato/recon/converter_app.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librecon/public/potato/recon/converter_config.h
+++ b/source/librecon/public/potato/recon/converter_config.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libreflex/public/potato/reflex/_wrapper.h
+++ b/source/libreflex/public/potato/reflex/_wrapper.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Potato Engine authors and contributors, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libreflex/public/potato/reflex/annotation.h
+++ b/source/libreflex/public/potato/reflex/annotation.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Potato Engine authors and contributors, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libreflex/public/potato/reflex/json_serializer.h
+++ b/source/libreflex/public/potato/reflex/json_serializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Potato Engine authors and contributors, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libreflex/public/potato/reflex/reflect.h
+++ b/source/libreflex/public/potato/reflex/reflect.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Potato Engine authors and contributors, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libreflex/public/potato/reflex/serializer.h
+++ b/source/libreflex/public/potato/reflex/serializer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Potato Engine authors and contributors, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libreflex/public/potato/reflex/traits.h
+++ b/source/libreflex/public/potato/reflex/traits.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Potato Engine authors and contributors, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/camera.cpp
+++ b/source/librender/private/camera.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/camera.h"
 #include "potato/render/context.h"

--- a/source/librender/private/d3d11_backend/d3d11_buffer.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_buffer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_buffer.h"
 #include "potato/spud/int_types.h"

--- a/source/librender/private/d3d11_backend/d3d11_buffer.h
+++ b/source/librender/private/d3d11_backend/d3d11_buffer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_command_list.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_command_list.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_command_list.h"
 #include "d3d11_pipeline_state.h"

--- a/source/librender/private/d3d11_backend/d3d11_command_list.h
+++ b/source/librender/private/d3d11_backend/d3d11_command_list.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_device.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_device.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/com_ptr.h"
 #include "d3d11_device.h"

--- a/source/librender/private/d3d11_backend/d3d11_device.h
+++ b/source/librender/private/d3d11_backend/d3d11_device.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_factory.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_factory.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_factory.h"
 #include "d3d11_device.h"

--- a/source/librender/private/d3d11_backend/d3d11_factory.h
+++ b/source/librender/private/d3d11_backend/d3d11_factory.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_pipeline_state.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_pipeline_state.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_pipeline_state.h"
 #include <potato/runtime/assertion.h>

--- a/source/librender/private/d3d11_backend/d3d11_pipeline_state.h
+++ b/source/librender/private/d3d11_backend/d3d11_pipeline_state.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_platform.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_platform.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_platform.h"
 #include <potato/runtime/assertion.h>

--- a/source/librender/private/d3d11_backend/d3d11_platform.h
+++ b/source/librender/private/d3d11_backend/d3d11_platform.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_resource_view.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_resource_view.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_resource_view.h"
 

--- a/source/librender/private/d3d11_backend/d3d11_resource_view.h
+++ b/source/librender/private/d3d11_backend/d3d11_resource_view.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_sampler.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_sampler.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_sampler.h"
 

--- a/source/librender/private/d3d11_backend/d3d11_sampler.h
+++ b/source/librender/private/d3d11_backend/d3d11_sampler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_swap_chain.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_swap_chain.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_swap_chain.h"
 #include "d3d11_texture.h"

--- a/source/librender/private/d3d11_backend/d3d11_swap_chain.h
+++ b/source/librender/private/d3d11_backend/d3d11_swap_chain.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/d3d11_backend/d3d11_texture.cpp
+++ b/source/librender/private/d3d11_backend/d3d11_texture.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d11_texture.h"
 #include "d3d11_platform.h"

--- a/source/librender/private/d3d11_backend/d3d11_texture.h
+++ b/source/librender/private/d3d11_backend/d3d11_texture.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/debug_draw.cpp
+++ b/source/librender/private/debug_draw.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/debug_draw.h"
 #include "potato/spud/vector.h"

--- a/source/librender/private/draw_imgui.cpp
+++ b/source/librender/private/draw_imgui.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/draw_imgui.h"
 #include "potato/render/shader.h"

--- a/source/librender/private/image.cpp
+++ b/source/librender/private/image.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/image.h"
 #include "potato/runtime/stream.h"

--- a/source/librender/private/material.cpp
+++ b/source/librender/private/material.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/material.h"
 #include "potato/render/context.h"

--- a/source/librender/private/mesh.cpp
+++ b/source/librender/private/mesh.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/mesh.h"
 #include "potato/render/context.h"

--- a/source/librender/private/model.cpp
+++ b/source/librender/private/model.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/model.h"
 #include "potato/render/material.h"

--- a/source/librender/private/null_backend/null_objects.cpp
+++ b/source/librender/private/null_backend/null_objects.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "null_objects.h"
 

--- a/source/librender/private/null_backend/null_objects.h
+++ b/source/librender/private/null_backend/null_objects.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/private/renderer.cpp
+++ b/source/librender/private/renderer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/spud/numeric_util.h"
 #include "potato/render/renderer.h"

--- a/source/librender/private/stb_impl.cpp
+++ b/source/librender/private/stb_impl.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STB_DXT_IMPLEMENTATION

--- a/source/librender/private/texture.cpp
+++ b/source/librender/private/texture.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/render/texture.h"
 #include "potato/render/context.h"

--- a/source/librender/public/potato/render/_export.h
+++ b/source/librender/public/potato/render/_export.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/camera.h
+++ b/source/librender/public/potato/render/camera.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/context.h
+++ b/source/librender/public/potato/render/context.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/debug_draw.h
+++ b/source/librender/public/potato/render/debug_draw.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/draw_imgui.h
+++ b/source/librender/public/potato/render/draw_imgui.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_buffer.h
+++ b/source/librender/public/potato/render/gpu_buffer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_command_list.h
+++ b/source/librender/public/potato/render/gpu_command_list.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_common.h
+++ b/source/librender/public/potato/render/gpu_common.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_device.h
+++ b/source/librender/public/potato/render/gpu_device.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_factory.h
+++ b/source/librender/public/potato/render/gpu_factory.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_pipeline_state.h
+++ b/source/librender/public/potato/render/gpu_pipeline_state.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_resource_view.h
+++ b/source/librender/public/potato/render/gpu_resource_view.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_sampler.h
+++ b/source/librender/public/potato/render/gpu_sampler.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_swap_chain.h
+++ b/source/librender/public/potato/render/gpu_swap_chain.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/gpu_texture.h
+++ b/source/librender/public/potato/render/gpu_texture.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/image.h
+++ b/source/librender/public/potato/render/image.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/loader.h
+++ b/source/librender/public/potato/render/loader.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/material.h
+++ b/source/librender/public/potato/render/material.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/mesh.h
+++ b/source/librender/public/potato/render/mesh.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/model.h
+++ b/source/librender/public/potato/render/model.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/pixel_format.h
+++ b/source/librender/public/potato/render/pixel_format.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/renderer.h
+++ b/source/librender/public/potato/render/renderer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/shader.h
+++ b/source/librender/public/potato/render/shader.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/librender/public/potato/render/texture.h
+++ b/source/librender/public/potato/render/texture.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/private/callstack.posix.cpp
+++ b/source/libruntime/private/callstack.posix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 22015 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/runtime/callstack.h>
 #include "potato/spud/platform.h"

--- a/source/libruntime/private/callstack.windows.cpp
+++ b/source/libruntime/private/callstack.windows.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 22015 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/callstack.h"
 #include "potato/spud/platform.h"

--- a/source/libruntime/private/debug.cpp
+++ b/source/libruntime/private/debug.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/debug.h"
 #include "potato/runtime/callstack.h"

--- a/source/libruntime/private/debug.posix.cpp
+++ b/source/libruntime/private/debug.posix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include <potato/runtime/debug.h>
 #include <cstdio>

--- a/source/libruntime/private/debug.windows.cpp
+++ b/source/libruntime/private/debug.windows.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "debug.windows.h"
 #include "potato/runtime/callstack.h"

--- a/source/libruntime/private/json.cpp
+++ b/source/libruntime/private/json.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/json.h"
 #include "potato/runtime/stream.h"

--- a/source/libruntime/private/logger.cpp
+++ b/source/libruntime/private/logger.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/logger.h"
 #include "potato/runtime/standard_stream_receiver.h"

--- a/source/libruntime/private/native.cpp
+++ b/source/libruntime/private/native.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/native.h"
 #include "potato/runtime/stream.h"

--- a/source/libruntime/private/native.default.cpp
+++ b/source/libruntime/private/native.default.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/native.h"
 #include <filesystem>

--- a/source/libruntime/private/native.posix.cpp
+++ b/source/libruntime/private/native.posix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/native.h"
 #include "potato/runtime/path.h"

--- a/source/libruntime/private/null.cpp
+++ b/source/libruntime/private/null.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/null.h"
 #include "potato/runtime/stream.h"

--- a/source/libruntime/private/path.cpp
+++ b/source/libruntime/private/path.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/path.h"
 #include <potato/runtime/assertion.h>

--- a/source/libruntime/private/semaphore.posix.cpp
+++ b/source/libruntime/private/semaphore.posix.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 // Inspired by the technique in the "LightweightSemaphore" at
 //   https://github.com/preshing/cpp11-on-multicore

--- a/source/libruntime/private/semaphore.windows.cpp
+++ b/source/libruntime/private/semaphore.windows.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 // Inspired by the technique in the "LightweightSemaphore" at
 //   https://github.com/preshing/cpp11-on-multicore

--- a/source/libruntime/private/standard_stream_receiver.cpp
+++ b/source/libruntime/private/standard_stream_receiver.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/standard_stream_receiver.h"
 #include "potato/runtime/lock_guard.h"

--- a/source/libruntime/private/stream.cpp
+++ b/source/libruntime/private/stream.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/stream.h"
 #include "potato/spud/string_writer.h"

--- a/source/libruntime/private/task_worker.cpp
+++ b/source/libruntime/private/task_worker.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/task_worker.h"
 #include "potato/runtime/semaphore.h"

--- a/source/libruntime/private/thread_util.cpp
+++ b/source/libruntime/private/thread_util.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/thread_util.h"
 #include <potato/runtime/assertion.h>

--- a/source/libruntime/private/thread_util.linux.cpp
+++ b/source/libruntime/private/thread_util.linux.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/thread_util.h"
 

--- a/source/libruntime/private/thread_util.windows.cpp
+++ b/source/libruntime/private/thread_util.windows.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/thread_util.h"
 #include "potato/spud/platform_windows.h"

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/uuid.h"
 #include "potato/runtime/assertion.h"

--- a/source/libruntime/private/uuid.linux.cpp
+++ b/source/libruntime/private/uuid.linux.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/uuid.h"
 #include "potato/spud/platform.h"

--- a/source/libruntime/private/uuid.windows.cpp
+++ b/source/libruntime/private/uuid.windows.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/uuid.h"
 #include "potato/runtime/assertion.h"

--- a/source/libruntime/private/win32_debug_receiver.windows.cpp
+++ b/source/libruntime/private/win32_debug_receiver.windows.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "potato/runtime/win32_debug_receiver.h"
 #include "potato/spud/platform_windows.h"

--- a/source/libruntime/public/potato/runtime/_export.h
+++ b/source/libruntime/public/potato/runtime/_export.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/assertion.h
+++ b/source/libruntime/public/potato/runtime/assertion.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/callstack.h
+++ b/source/libruntime/public/potato/runtime/callstack.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/com_ptr.h
+++ b/source/libruntime/public/potato/runtime/com_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/common.h
+++ b/source/libruntime/public/potato/runtime/common.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/concurrent_queue.h
+++ b/source/libruntime/public/potato/runtime/concurrent_queue.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/debug.h
+++ b/source/libruntime/public/potato/runtime/debug.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/filesystem.h
+++ b/source/libruntime/public/potato/runtime/filesystem.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/json.h
+++ b/source/libruntime/public/potato/runtime/json.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/lock_free_queue.h
+++ b/source/libruntime/public/potato/runtime/lock_free_queue.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 // http://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue
 

--- a/source/libruntime/public/potato/runtime/lock_guard.h
+++ b/source/libruntime/public/potato/runtime/lock_guard.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/log_receiver.h
+++ b/source/libruntime/public/potato/runtime/log_receiver.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/log_severity.h
+++ b/source/libruntime/public/potato/runtime/log_severity.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/logger.h
+++ b/source/libruntime/public/potato/runtime/logger.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/native.h
+++ b/source/libruntime/public/potato/runtime/native.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/null.h
+++ b/source/libruntime/public/potato/runtime/null.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/path.h
+++ b/source/libruntime/public/potato/runtime/path.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/rwlock.h
+++ b/source/libruntime/public/potato/runtime/rwlock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/semaphore.h
+++ b/source/libruntime/public/potato/runtime/semaphore.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/spinlock.h
+++ b/source/libruntime/public/potato/runtime/spinlock.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/standard_stream_receiver.h
+++ b/source/libruntime/public/potato/runtime/standard_stream_receiver.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/stream.h
+++ b/source/libruntime/public/potato/runtime/stream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/task_worker.h
+++ b/source/libruntime/public/potato/runtime/task_worker.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/thread_util.h
+++ b/source/libruntime/public/potato/runtime/thread_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2016,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/vfs.h
+++ b/source/libruntime/public/potato/runtime/vfs.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/libruntime/public/potato/runtime/win32_debug_receiver.h
+++ b/source/libruntime/public/potato/runtime/win32_debug_receiver.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/_assertion.h
+++ b/source/spud/public/potato/spud/_assertion.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/bit_set.h
+++ b/source/spud/public/potato/spud/bit_set.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/box.h
+++ b/source/spud/public/potato/spud/box.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/const_util.h
+++ b/source/spud/public/potato/spud/const_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/delegate.h
+++ b/source/spud/public/potato/spud/delegate.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/delegate_ref.h
+++ b/source/spud/public/potato/spud/delegate_ref.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/find.h
+++ b/source/spud/public/potato/spud/find.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/fixed_string.h
+++ b/source/spud/public/potato/spud/fixed_string.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/fixed_string_writer.h
+++ b/source/spud/public/potato/spud/fixed_string_writer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/functional.h
+++ b/source/spud/public/potato/spud/functional.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/hash.h
+++ b/source/spud/public/potato/spud/hash.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 // Based on Howard Hinnant's "Types Don't Know #"
 

--- a/source/spud/public/potato/spud/hash_fnv1a.h
+++ b/source/spud/public/potato/spud/hash_fnv1a.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/int_types.h
+++ b/source/spud/public/potato/spud/int_types.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/memory_util.h
+++ b/source/spud/public/potato/spud/memory_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/numeric_util.h
+++ b/source/spud/public/potato/spud/numeric_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/out_ptr.h
+++ b/source/spud/public/potato/spud/out_ptr.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/platform.h
+++ b/source/spud/public/potato/spud/platform.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/platform_windows.h
+++ b/source/spud/public/potato/spud/platform_windows.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/preprocessor.h
+++ b/source/spud/public/potato/spud/preprocessor.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/rc.h
+++ b/source/spud/public/potato/spud/rc.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/soa_layout.h
+++ b/source/spud/public/potato/spud/soa_layout.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/sort.h
+++ b/source/spud/public/potato/spud/sort.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/span.h
+++ b/source/spud/public/potato/spud/span.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/std_hash.h
+++ b/source/spud/public/potato/spud/std_hash.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 // Based on Howard Hinnant's "Types Don't Know #"
 

--- a/source/spud/public/potato/spud/std_iostream.h
+++ b/source/spud/public/potato/spud/std_iostream.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/string.h
+++ b/source/spud/public/potato/spud/string.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/string_format.h
+++ b/source/spud/public/potato/spud/string_format.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/string_util.h
+++ b/source/spud/public/potato/spud/string_util.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/string_view.h
+++ b/source/spud/public/potato/spud/string_view.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/string_writer.h
+++ b/source/spud/public/potato/spud/string_writer.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2014,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/tie_struct.h
+++ b/source/spud/public/potato/spud/tie_struct.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/traits.h
+++ b/source/spud/public/potato/spud/traits.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/typelist.h
+++ b/source/spud/public/potato/spud/typelist.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2017,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/unique_resource.h
+++ b/source/spud/public/potato/spud/unique_resource.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/utility.h
+++ b/source/spud/public/potato/spud/utility.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/vector.h
+++ b/source/spud/public/potato/spud/vector.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2015,2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 

--- a/source/spud/public/potato/spud/zstring_view.h
+++ b/source/spud/public/potato/spud/zstring_view.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2019 Sean Middleditch, all rights reserverd.
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #pragma once
 


### PR DESCRIPTION
Replace ad-hoc year-based copyright headers with a cleaner yearless standard header.