### PR TITLE
Fix component addition/removal

### DIFF
--- a/source/libecs/private/entity_id.h
+++ b/source/libecs/private/entity_id.h
@@ -7,13 +7,13 @@
 #include "potato/spud/int_types.h"
 
 namespace up {
-    static constexpr auto makeEntityId(uint32 mappingIndex, uint32 generation) noexcept -> EntityId {
-        return static_cast<EntityId>((static_cast<uint64>(generation) << 32) | mappingIndex);
+    static constexpr auto makeEntityId(uint64 mappingIndex, uint16 generation) noexcept -> EntityId {
+        return static_cast<EntityId>((static_cast<uint64>(generation) << 48) | mappingIndex);
     }
 
-    static constexpr auto getEntityMappingIndex(EntityId entity) noexcept -> uint32 { return static_cast<uint64>(entity) & 0xFFFFFFFF; }
+    static constexpr auto getEntityMappingIndex(EntityId entity) noexcept -> uint64 { return static_cast<uint64>(entity) & ((1ull << 48) - 1); }
 
-    static constexpr auto getEntityGeneration(EntityId entity) noexcept -> uint32 { return static_cast<uint64>(entity) >> 32; }
+    static constexpr auto getEntityGeneration(EntityId entity) noexcept -> uint16 { return static_cast<uint64>(entity) >> 48; }
 
     static constexpr auto makeMapped(uint16 generation, uint16 archetypeIndex, uint16 chunkIndex, uint16 entityIndex) -> uint64 {
         return (static_cast<uint64>(generation) << 48) | (static_cast<uint64>(archetypeIndex) << 32) | (static_cast<uint64>(chunkIndex) << 16) |
@@ -24,11 +24,11 @@ namespace up {
 
     static constexpr auto getMappedIndex(uint64 mapping) noexcept -> uint16 { return static_cast<uint16>(mapping); }
 
-    static constexpr auto getMappedGeneration(uint64 mapping) noexcept -> uint32 { return static_cast<uint32>(mapping >> 48); }
+    static constexpr auto getMappedGeneration(uint64 mapping) noexcept -> uint16 { return static_cast<uint16>(mapping >> 48); }
 
     static constexpr auto getMappedArchetype(uint64 mapping) noexcept -> uint16 { return static_cast<uint16>(mapping >> 32); }
 
-    static constexpr auto makeFreeEntry(uint16 generation, uint32 index) noexcept -> uint64 {
-        return (static_cast<uint64>(generation) << 48) | static_cast<uint64>(index);
+    static constexpr auto makeFreeEntry(uint16 generation, uint64 index) noexcept -> uint64 {
+        return (static_cast<uint64>(generation) << 48) | index;
     }
 } // namespace up

--- a/source/libecs/tests/test_world.cpp
+++ b/source/libecs/tests/test_world.cpp
@@ -153,6 +153,10 @@ DOCTEST_TEST_SUITE("[potato][ecs] World") {
             found = false;
             queryTest1.select(world, [&found](EntityId, Test1&) { found = true; });
             DOCTEST_CHECK(found);
+
+            found = false;
+            world.interrogateEntityUnsafe(id, [&found](EntityId, ArchetypeId, ComponentMeta const* meta, void*) { found = true; });
+            DOCTEST_CHECK(found);
         }
 
         DOCTEST_SUBCASE("Add Component") {


### PR DESCRIPTION
Prior simplication caused EntityIds to be corrupted.

Added a test to ensure this is caught if it breaks again.