### PR TITLE
Explicit message for after a manifest is written

### DIFF
--- a/source/bin_recon/private/recon_app.cpp
+++ b/source/bin_recon/private/recon_app.cpp
@@ -20,17 +20,6 @@
 
 #include <nlohmann/json.hpp>
 
-namespace up::recon {
-    namespace {
-        template <derived_from<schema::ReconMessage> MessageT>
-        void sendMessage(MessageT const& message) {
-            nlohmann::json doc;
-            encodeReconMessage(doc, message);
-            std::cout << doc.dump() << '\r\n';
-        }
-    } // namespace
-} // namespace up::recon
-
 up::recon::ReconApp::ReconApp() : _programName("recon"), _logger("recon") {}
 
 up::recon::ReconApp::~ReconApp() = default;

--- a/source/bin_recon/private/recon_app.cpp
+++ b/source/bin_recon/private/recon_app.cpp
@@ -499,7 +499,7 @@ bool up::recon::ReconApp::_writeManifest() {
         msg.path = _manifestPath;
         nlohmann::json doc;
         encodeReconMessage(doc, msg);
-        std::cout << doc.dump() << '\r\n';
+        std::cout << doc.dump() << "\r\n";
     }
 
     return true;

--- a/source/bin_recon/private/recon_app.h
+++ b/source/bin_recon/private/recon_app.h
@@ -58,6 +58,7 @@ namespace up::recon {
         box<Project> _project;
         string_view _programName;
         string _temporaryOutputPath;
+        string _manifestPath;
         vector<Mapping> _importers;
         vector<string> _outputs;
         ReconConfig _config;

--- a/source/librecon/private/recon_client.cpp
+++ b/source/librecon/private/recon_client.cpp
@@ -85,11 +85,15 @@ bool up::shell::ReconClient::hasUpdatedAssets() noexcept {
 
 bool up::shell::ReconClient::handleMessage(reflex::Schema const& schema, schema::ReconMessage const& msg) {
     static reflex::Schema const& logSchema = reflex::getSchema<schema::ReconLogMessage>();
+    static reflex::Schema const& manifestSchema = reflex::getSchema<schema::ReconManifestMessage>();
 
-    if (&schema == &logSchema) {
+    if (schema.name == logSchema.name) {
         auto const& log = static_cast<schema::ReconLogMessage const&>(msg);
         s_logger.log(log.severity, log.message);
+        return true;
+    }
 
+    if (schema.name == manifestSchema.name) {
         _staleAssets.store(true);
         return true;
     }

--- a/source/librecon/schema/recon_messages.sap
+++ b/source/librecon/schema/recon_messages.sap
@@ -25,3 +25,7 @@ struct ReconImportMessage : ReconMessage {
 struct ReconImportAllMessage : ReconMessage {
     bool force = false;
 }
+
+struct ReconManifestMessage : ReconMessage {
+    string path;
+}


### PR DESCRIPTION
- Replaces assuming the manifest is dirty after each log message
- Flushes manifest stream before sending message

Should fix the race condition that results in the manifest sometimes being corrupted