### PR TITLE
Plumb UUID as primary source asset ID

### DIFF
--- a/resources/materials/basic.mat
+++ b/resources/materials/basic.mat
@@ -1,9 +1,9 @@
 {
-  "shaders": {
-    "vertex": "shaders/basic.hlsl",
-    "pixel": "shaders/basic.hlsl"
-  },
-  "textures": [
-    "textures/test.png"
-  ]
+    "shaders": {
+        "vertex": "51ba5cbf-6ccf-d642-8e3f-3353f6ad9d69",
+        "pixel": "51ba5cbf-6ccf-d642-8e3f-3353f6ad9d69"
+    },
+    "textures": [
+        "c6406bb1-cec1-6b40-9fbd-81d4066be5c3"
+    ]
 }

--- a/resources/materials/full.mat
+++ b/resources/materials/full.mat
@@ -1,11 +1,11 @@
 {
-  "shaders": {
-    "vertex": "shaders/full.hlsl",
-    "pixel": "shaders/full.hlsl"
-  },
-  "textures": [
-    "textures/rock_d.jpg",
-    "textures/rock_n.jpg",
-    "textures/rock_ao.jpg"
-  ]
+    "shaders": {
+        "vertex": "96d7f040-9d15-c74f-b6c9-2226c1fe3f61",
+        "pixel": "96d7f040-9d15-c74f-b6c9-2226c1fe3f61"
+    },
+    "textures": [
+        "e18259a1-0d35-c341-b99f-78a33771a979",
+        "e6180b41-cb1e-b444-b58e-005eaac33dda",
+        "d078592f-40ad-454d-9ecf-12c10ceb963a"
+    ]
 }

--- a/source/bin_recon/private/recon_app.cpp
+++ b/source/bin_recon/private/recon_app.cpp
@@ -318,7 +318,7 @@ bool up::recon::ReconApp::_importFile(zstring_view file, bool force) {
             newRecord.sourcePath,
             output.logicalAsset.empty() ? "" : ":",
             output.logicalAsset);
-        auto const logicalAssetId = _library.createLogicalAssetId(context.uuid(), logicalAssetName);
+        auto const logicalAssetId = AssetLibrary::createLogicalAssetId(context.uuid(), output.logicalAsset);
 
         newRecord.outputs.push_back(
             {.name = output.logicalAsset,

--- a/source/bin_shell/private/editors/asset_browser.cpp
+++ b/source/bin_shell/private/editors/asset_browser.cpp
@@ -13,6 +13,7 @@
 #include "potato/spud/numeric_util.h"
 #include "potato/spud/sequence.h"
 #include "potato/spud/string.h"
+#include "potato/spud/string_format.h"
 #include "potato/spud/vector.h"
 
 #include <imgui.h>
@@ -98,6 +99,14 @@ void up::shell::AssetBrowser::_showAssets(int folderIndex) {
             if (ImGui::BeginPopupContextItem()) {
                 if (ImGui::IconMenuItem("Edit Asset", ICON_FA_EDIT)) {
                     _handleFileClick(asset.filename);
+                }
+                if (ImGui::IconMenuItem("Copy Path", ICON_FA_COPY)) {
+                    ImGui::SetClipboardText(asset.filename.c_str());
+                }
+                if (ImGui::IconMenuItem("Copy UUID")) {
+                    char buf[UUID::strLength] = {0};
+                    format_to(buf, "{}", asset.uuid);
+                    ImGui::SetClipboardText(buf);
                 }
                 if (ImGui::IconMenuItem("Open Folder in Explorer", ICON_FA_FOLDER_OPEN)) {
                     _handleFileClick(string{path::parent(asset.filename)});
@@ -213,7 +222,9 @@ void up::shell::AssetBrowser::_rebuild() {
         }
 
         _assets.push_back(
-            {.filename = string{record.filename},
+            {.uuid = record.uuid,
+             .logicalAssetId = static_cast<AssetId>(record.logicalId),
+             .filename = string{record.filename},
              .name = string{record.filename.substr(start)},
              .type = string{record.type},
              .folderIndex = folderIndex});

--- a/source/bin_shell/private/editors/asset_browser.h
+++ b/source/bin_shell/private/editors/asset_browser.h
@@ -6,6 +6,7 @@
 
 #include "potato/editor/asset_edit_service.h"
 #include "potato/runtime/asset_loader.h"
+#include "potato/runtime/uuid.h"
 #include "potato/spud/delegate.h"
 #include "potato/spud/hash.h"
 #include "potato/spud/string.h"
@@ -50,6 +51,8 @@ namespace up::shell {
         };
 
         struct Asset {
+            UUID uuid;
+            AssetId logicalAssetId = AssetId::Invalid;
             string filename;
             string name;
             string type;

--- a/source/bin_shell/private/editors/scene_editor.cpp
+++ b/source/bin_shell/private/editors/scene_editor.cpp
@@ -54,19 +54,21 @@ namespace up::shell {
                 auto scene = new_shared<Scene>(_universe, _audioEngine);
                 auto doc = new_box<SceneDocument>(string(filename), std::move(scene));
 
-#if 0
-                auto material = _assetLoader.loadAssetSync<Material>(_assetLoader.translate("materials/full.mat"));
+#if 1
+                auto material = _assetLoader.loadAssetSync<Material>(
+                    _assetLoader.translate(UUID::fromString("1fe16c8f-6225-f246-9df4-824e34a28913")));
                 if (!material.isSet()) {
                     return nullptr;
                 }
 
-                auto mesh = _assetLoader.loadAssetSync<Mesh>(_assetLoader.translate("meshes/cube.obj"));
+                auto mesh = _assetLoader.loadAssetSync<Mesh>(
+                    _assetLoader.translate(UUID::fromString("8b589d73-8596-6a45-962b-4816b33d9ca3")));
                 if (!mesh.isSet()) {
                     return nullptr;
                 }
 
-                auto ding =
-                    _assetLoader.loadAssetSync<SoundResource>(_assetLoader.translate("audio/kenney/highUp.mp3"));
+                auto ding = _assetLoader.loadAssetSync<SoundResource>(
+                    _assetLoader.translate(UUID::fromString("df3a7c47-d06a-cc44-abc4-e928aa4ab035")));
                 if (!ding.isSet()) {
                     return nullptr;
                 }

--- a/source/librender/private/material.cpp
+++ b/source/librender/private/material.cpp
@@ -63,6 +63,13 @@ void up::Material::bindMaterialToRender(RenderContext& ctx) {
     }
 }
 
+static auto toUUID(up::schema::UUID const& src) noexcept -> up::UUID {
+    flatbuffers::Array<int8_t, 16> const& arr = *src.b();
+    up::byte const* bytes = reinterpret_cast<up::byte const*>(arr.data());
+    up::UUID const result{bytes, arr.size()};
+    return result;
+}
+
 auto up::Material::createFromBuffer(AssetId id, view<byte> buffer, AssetLoader& assetLoader) -> rc<Material> {
     flatbuffers::Verifier verifier(reinterpret_cast<uint8 const*>(buffer.data()), buffer.size());
     if (!schema::VerifyMaterialBuffer(verifier)) {
@@ -80,13 +87,11 @@ auto up::Material::createFromBuffer(AssetId id, view<byte> buffer, AssetLoader& 
         return nullptr;
     }
 
-    auto vertexPath = shader->vertex();
-    auto pixelPath = shader->pixel();
+    auto const vertexUuid = toUUID(*shader->vertex());
+    auto const pixelUuid = toUUID(*shader->pixel());
 
-    vertex = assetLoader.loadAssetSync<Shader>(
-        assetLoader.translate(string_view(vertexPath->c_str(), vertexPath->size()), "vertex"_sv));
-    pixel = assetLoader.loadAssetSync<Shader>(
-        assetLoader.translate(string_view(pixelPath->c_str(), pixelPath->size()), "pixel"_sv));
+    vertex = assetLoader.loadAssetSync<Shader>(assetLoader.translate(vertexUuid, "vertex"_sv));
+    pixel = assetLoader.loadAssetSync<Shader>(assetLoader.translate(pixelUuid, "pixel"_sv));
 
     if (!vertex.ready()) {
         return nullptr;
@@ -97,9 +102,9 @@ auto up::Material::createFromBuffer(AssetId id, view<byte> buffer, AssetLoader& 
     }
 
     for (auto textureData : *material->textures()) {
-        auto texturePath = string(textureData->c_str(), textureData->size());
+        auto const textureUuid = toUUID(*textureData);
 
-        auto tex = assetLoader.loadAssetSync<Texture>(assetLoader.translate(texturePath));
+        auto tex = assetLoader.loadAssetSync<Texture>(assetLoader.translate(textureUuid));
         if (!tex.ready()) {
             return nullptr;
         }

--- a/source/librender/private/material.cpp
+++ b/source/librender/private/material.cpp
@@ -65,9 +65,8 @@ void up::Material::bindMaterialToRender(RenderContext& ctx) {
 
 static auto toUUID(up::schema::UUID const& src) noexcept -> up::UUID {
     flatbuffers::Array<int8_t, 16> const& arr = *src.b();
-    up::byte const* bytes = reinterpret_cast<up::byte const*>(arr.data());
-    up::UUID const result{bytes, arr.size()};
-    return result;
+    auto const* bytes = reinterpret_cast<up::byte const*>(arr.data());
+    return {bytes, arr.size()};
 }
 
 auto up::Material::createFromBuffer(AssetId id, view<byte> buffer, AssetLoader& assetLoader) -> rc<Material> {

--- a/source/librender/schemas/material.fbs
+++ b/source/librender/schemas/material.fbs
@@ -1,13 +1,17 @@
 namespace up.schema;
 
+struct UUID {
+    b:[byte:16];
+}
+
 table MaterialShader {
-    vertex:string;
-    pixel:string;
+    vertex:UUID;
+    pixel:UUID;
 }
 
 table Material {
     shader:MaterialShader;
-    textures:[string];
+    textures:[UUID];
 }
 
 root_type Material;

--- a/source/libruntime/private/asset_loader.cpp
+++ b/source/libruntime/private/asset_loader.cpp
@@ -23,7 +23,7 @@ void up::AssetLoader::bindManifest(box<ResourceManifest> manifest, string casPat
     _casPath = std::move(casPath);
 }
 
-auto up::AssetLoader::translate(UUID uuid, string_view logicalName) const -> AssetId {
+auto up::AssetLoader::translate(UUID const& uuid, string_view logicalName) const -> AssetId {
     uint64 hash = hash_value(uuid);
     if (!logicalName.empty()) {
         hash = hash_combine(hash, hash_value(logicalName));

--- a/source/libruntime/private/resource_manifest.cpp
+++ b/source/libruntime/private/resource_manifest.cpp
@@ -16,14 +16,14 @@ bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& ma
     int debugNameColumn = -1;
 
     enum ColumnMask {
-        ColumnRootIdMask = (1 << 0),
+        ColumnUuidMask = (1 << 0),
         ColumnLogicalIdMask = (1 << 1),
         ColumnLogicalNameMask = (1 << 2),
         ColumnContentHashMask = (1 << 3),
         ColumnDebugNameMask = (1 << 4),
         ColumnContentTypeMask = (1 << 5),
-        ColumnRequiredMask = ColumnRootIdMask | ColumnLogicalIdMask | ColumnLogicalNameMask | ColumnContentHashMask |
-            ColumnContentTypeMask
+        ColumnRequiredMask =
+            ColumnUuidMask | ColumnLogicalIdMask | ColumnLogicalNameMask | ColumnContentHashMask | ColumnContentTypeMask
     };
 
     string_view::size_type sep = 0;
@@ -63,9 +63,9 @@ bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& ma
                 while (!eol && (sep = input.find_first_of("|\n")) != string_view::npos) {
                     string_view const header = input.substr(0, sep);
 
-                    if (header == columnRootId) {
+                    if (header == columnUuid) {
                         rootIdColumn = column;
-                        mask |= ColumnRootIdMask;
+                        mask |= ColumnUuidMask;
                     }
                     else if (header == columnLogicalId) {
                         logicalIdColumn = column;
@@ -107,8 +107,8 @@ bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& ma
                     string_view const data = input.substr(0, sep);
 
                     if (column == rootIdColumn) {
-                        std::from_chars(data.begin(), data.end(), static_cast<uint64&>(record.rootId), 16);
-                        mask |= ColumnRootIdMask;
+                        record.uuid = UUID::fromString(data);
+                        mask |= ColumnUuidMask;
                     }
                     else if (column == logicalIdColumn) {
                         std::from_chars(data.begin(), data.end(), static_cast<uint64&>(record.logicalId), 16);

--- a/source/libruntime/private/resource_manifest.cpp
+++ b/source/libruntime/private/resource_manifest.cpp
@@ -10,7 +10,6 @@
 bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& manifest) {
     int rootIdColumn = -1;
     int logicalIdColumn = -1;
-    int logicalNameColumn = -1;
     int contentHashColumn = -1;
     int contentTypeColumn = -1;
     int debugNameColumn = -1;
@@ -18,12 +17,10 @@ bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& ma
     enum ColumnMask {
         ColumnUuidMask = (1 << 0),
         ColumnLogicalIdMask = (1 << 1),
-        ColumnLogicalNameMask = (1 << 2),
         ColumnContentHashMask = (1 << 3),
         ColumnDebugNameMask = (1 << 4),
         ColumnContentTypeMask = (1 << 5),
-        ColumnRequiredMask =
-            ColumnUuidMask | ColumnLogicalIdMask | ColumnLogicalNameMask | ColumnContentHashMask | ColumnContentTypeMask
+        ColumnRequiredMask = ColumnUuidMask | ColumnLogicalIdMask | ColumnContentHashMask | ColumnContentTypeMask
     };
 
     string_view::size_type sep = 0;
@@ -71,10 +68,6 @@ bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& ma
                         logicalIdColumn = column;
                         mask |= ColumnLogicalIdMask;
                     }
-                    else if (header == columnLogicalName) {
-                        logicalNameColumn = column;
-                        mask |= ColumnLogicalNameMask;
-                    }
                     else if (header == columnContentHash) {
                         contentHashColumn = column;
                         mask |= ColumnContentHashMask;
@@ -113,10 +106,6 @@ bool up::ResourceManifest::parseManifest(string_view input, ResourceManifest& ma
                     else if (column == logicalIdColumn) {
                         std::from_chars(data.begin(), data.end(), static_cast<uint64&>(record.logicalId), 16);
                         mask |= ColumnLogicalIdMask;
-                    }
-                    else if (column == logicalNameColumn) {
-                        std::from_chars(data.begin(), data.end(), static_cast<uint64&>(record.logicalName), 16);
-                        mask |= ColumnLogicalNameMask;
                     }
                     else if (column == contentHashColumn) {
                         std::from_chars(data.begin(), data.end(), record.hash, 16);

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -6,8 +6,9 @@
 #include "potato/spud/ascii.h"
 #include "potato/spud/string_writer.h"
 
-constexpr up::UUID::UUID(Bytes const& bytes) noexcept : _data{HighLow{}} {
-    for (unsigned i = 0; i != sizeof(bytes); ++i) {
+up::UUID::UUID(up::byte const* bytes, size_t length) noexcept : _data{HighLow{}} {
+    UP_ASSERT(length == octects);
+    for (unsigned i = 0; i != octects; ++i) {
         _data.ub[i] = bytes[i];
     }
 }

--- a/source/libruntime/private/uuid.cpp
+++ b/source/libruntime/private/uuid.cpp
@@ -17,28 +17,8 @@ constexpr char byteToString(up::byte byte) noexcept {
 }
 
 auto up::UUID::toString() const -> string {
-    // format 9554084e-4100-4098-b470-2125f5eed133
     string_writer buffer;
-    format_append(
-        buffer,
-        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        _data.ub[0],
-        _data.ub[1],
-        _data.ub[2],
-        _data.ub[3],
-        _data.ub[4],
-        _data.ub[5],
-        _data.ub[6],
-        _data.ub[7],
-        _data.ub[8],
-        _data.ub[9],
-        _data.ub[10],
-        _data.ub[11],
-        _data.ub[12],
-        _data.ub[13],
-        _data.ub[14],
-        _data.ub[15]);
-
+    format_append(buffer, "{}", *this);
     return buffer.c_str();
 }
 

--- a/source/libruntime/public/potato/runtime/asset_loader.h
+++ b/source/libruntime/public/potato/runtime/asset_loader.h
@@ -42,7 +42,7 @@ namespace up {
 
         UP_RUNTIME_API void bindManifest(box<ResourceManifest> manifest, string casPath);
 
-        UP_RUNTIME_API AssetId translate(UUID uuid, string_view logicalName = {}) const;
+        UP_RUNTIME_API AssetId translate(UUID const& uuid, string_view logicalName = {}) const;
         UP_RUNTIME_API zstring_view debugName(AssetId logicalId) const noexcept;
 
         template <typename AssetT>

--- a/source/libruntime/public/potato/runtime/asset_loader.h
+++ b/source/libruntime/public/potato/runtime/asset_loader.h
@@ -5,6 +5,7 @@
 #include "_export.h"
 #include "asset.h"
 #include "logger.h"
+#include "uuid.h"
 
 #include "potato/spud/box.h"
 #include "potato/spud/rc.h"
@@ -41,7 +42,7 @@ namespace up {
 
         UP_RUNTIME_API void bindManifest(box<ResourceManifest> manifest, string casPath);
 
-        UP_RUNTIME_API AssetId translate(string_view assetName, string_view logicalName = {}) const;
+        UP_RUNTIME_API AssetId translate(UUID uuid, string_view logicalName = {}) const;
         UP_RUNTIME_API zstring_view debugName(AssetId logicalId) const noexcept;
 
         template <typename AssetT>

--- a/source/libruntime/public/potato/runtime/resource_manifest.h
+++ b/source/libruntime/public/potato/runtime/resource_manifest.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "_export.h"
+#include "uuid.h"
 
 #include "potato/format/erased.h"
 #include "potato/spud/int_types.h"
@@ -16,7 +17,7 @@ namespace up {
         using Id = uint64;
 
         struct Record {
-            Id rootId = {};
+            UUID uuid = {};
             Id logicalId = {};
             uint64 logicalName = 0;
             uint64 hash = 0;
@@ -24,7 +25,7 @@ namespace up {
             string type;
         };
 
-        static constexpr zstring_view columnRootId = "ROOT_ID"_zsv;
+        static constexpr zstring_view columnUuid = "UUID"_zsv;
         static constexpr zstring_view columnLogicalId = "LOGICAL_ID"_zsv;
         static constexpr zstring_view columnLogicalName = "LOGICAL_NAME"_zsv;
         static constexpr zstring_view columnContentType = "CONTENT_TYPE"_zsv;

--- a/source/libruntime/public/potato/runtime/resource_manifest.h
+++ b/source/libruntime/public/potato/runtime/resource_manifest.h
@@ -19,7 +19,6 @@ namespace up {
         struct Record {
             UUID uuid = {};
             Id logicalId = {};
-            uint64 logicalName = 0;
             uint64 hash = 0;
             string filename;
             string type;
@@ -27,7 +26,6 @@ namespace up {
 
         static constexpr zstring_view columnUuid = "UUID"_zsv;
         static constexpr zstring_view columnLogicalId = "LOGICAL_ID"_zsv;
-        static constexpr zstring_view columnLogicalName = "LOGICAL_NAME"_zsv;
         static constexpr zstring_view columnContentType = "CONTENT_TYPE"_zsv;
         static constexpr zstring_view columnContentHash = "CONTENT_HASH"_zsv;
         static constexpr zstring_view columnDebugName = "DEBUG_NAME"_zsv;

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -20,7 +20,8 @@ namespace up {
 
         constexpr UUID() noexcept : _data{HighLow{}} {}
         constexpr UUID(UUID const& rhs) noexcept : _data{rhs._data.u64} {}
-        constexpr UUID(Bytes const& bytes) noexcept;
+        explicit UUID(Bytes const& bytes) noexcept : UUID(bytes, sizeof(bytes)) {}
+        UUID(up::byte const* bytes, size_t length) noexcept;
 
         constexpr bool isValid() const noexcept { return _data.u64.high != 0 || _data.u64.low != 0; }
 
@@ -32,6 +33,8 @@ namespace up {
         }
 
         auto toString() const -> string;
+
+        up::byte const* bytes() const noexcept { return _data.ub; }
 
         template <format_writable FormatterT>
         friend void format_value(FormatterT& writer, UUID uuid) {

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -5,6 +5,7 @@
 #include "_export.h"
 
 #include "potato/spud/string.h"
+#include "potato/spud/string_format.h"
 
 #include <array>
 
@@ -29,6 +30,30 @@ namespace up {
         }
 
         auto toString() const -> string;
+
+        template <format_writable FormatterT>
+        friend void format_value(FormatterT& writer, UUID uuid) {
+            // format 9554084e-4100-4098-b470-2125f5eed133
+            format_to(
+                writer,
+                "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+                uuid._data.ub[0],
+                uuid._data.ub[1],
+                uuid._data.ub[2],
+                uuid._data.ub[3],
+                uuid._data.ub[4],
+                uuid._data.ub[5],
+                uuid._data.ub[6],
+                uuid._data.ub[7],
+                uuid._data.ub[8],
+                uuid._data.ub[9],
+                uuid._data.ub[10],
+                uuid._data.ub[11],
+                uuid._data.ub[12],
+                uuid._data.ub[13],
+                uuid._data.ub[14],
+                uuid._data.ub[15]);
+        }
 
         static auto generate() noexcept -> UUID;
         static auto fromString(string_view id) noexcept -> UUID;

--- a/source/libruntime/public/potato/runtime/uuid.h
+++ b/source/libruntime/public/potato/runtime/uuid.h
@@ -4,6 +4,7 @@
 
 #include "_export.h"
 
+#include "potato/spud/hash.h"
 #include "potato/spud/string.h"
 #include "potato/spud/string_format.h"
 
@@ -14,6 +15,7 @@ namespace up {
     class UP_RUNTIME_API UUID {
     public:
         static constexpr int octects = 16;
+        static constexpr int strLength = 37; // 32 hex values, four dashes, and NUL
         using Bytes = up::byte[octects];
 
         constexpr UUID() noexcept : _data{HighLow{}} {}
@@ -53,6 +55,14 @@ namespace up {
                 uuid._data.ub[13],
                 uuid._data.ub[14],
                 uuid._data.ub[15]);
+        }
+
+        template <typename HashAlgorithm = default_hash>
+        friend uint64 hash_value(UUID uuid) noexcept {
+            HashAlgorithm hasher{};
+            hash_append(hasher, uuid._data.u64.high);
+            hash_append(hasher, uuid._data.u64.low);
+            return hasher.finalize();
         }
 
         static auto generate() noexcept -> UUID;

--- a/source/libruntime/tests/test_resource_manifest.cpp
+++ b/source/libruntime/tests/test_resource_manifest.cpp
@@ -13,9 +13,9 @@ TEST_CASE("ResourceManifest", "[potato][runtime]") {
             "\n" // blank
             ".meta=value\n"
             ".key=var\n"
-            ":ROOT_ID|LOGICAL_ID|LOGICAL_NAME|CONTENT_TYPE|CONTENT_HASH|DEBUG_NAME\n"
-            "0|0|0|nil|DEAD|zero\n"
-            "1|1|0|bin|C0DE|one\n"
+            ":UUID|LOGICAL_ID|LOGICAL_NAME|CONTENT_TYPE|CONTENT_HASH|DEBUG_NAME\n"
+            "D8E02451-6D48-49F6-A2D3-9281379CB75A|0|0|nil|DEAD|zero\n"
+            "F2D1B621-9A00-4263-9786-80073F493796|1|0|bin|C0DE|one\n"
             ""_sv;
         ResourceManifest manifest;
         auto parseResult = ResourceManifest::parseManifest(input, manifest);
@@ -23,11 +23,11 @@ TEST_CASE("ResourceManifest", "[potato][runtime]") {
 
         CHECK(manifest.size() == 2);
 
-        CHECK(manifest.records().front().rootId == 0);
+        CHECK(manifest.records().front().uuid == UUID::fromString("D8E02451-6D48-49F6-A2D3-9281379CB75A"));
         CHECK(manifest.records().front().hash == 0xDEAD);
         CHECK(string_view{manifest.records().front().filename} == "zero"_sv);
 
-        CHECK(manifest.records().back().rootId == 1);
+        CHECK(manifest.records().back().uuid == UUID::fromString("F2D1B621-9A00-4263-9786-80073F493796"));
         CHECK(manifest.records().back().hash == 0xC0DE);
         CHECK(string_view{manifest.records().back().filename} == "one"_sv);
     }

--- a/source/libtools/private/asset_library.cpp
+++ b/source/libtools/private/asset_library.cpp
@@ -21,12 +21,12 @@ auto up::AssetLibrary::pathToUuid(string_view path) const noexcept -> UUID {
     return {};
 }
 
-auto up::AssetLibrary::uuidToPath(UUID uuid) const noexcept -> string_view {
+auto up::AssetLibrary::uuidToPath(UUID const& uuid) const noexcept -> string_view {
     auto record = findRecordByUuid(uuid);
     return record != nullptr ? string_view(record->sourcePath) : string_view{};
 }
 
-auto up::AssetLibrary::findRecordByUuid(UUID uuid) const noexcept -> Imported const* {
+auto up::AssetLibrary::findRecordByUuid(UUID const& uuid) const noexcept -> Imported const* {
     for (auto const& record : _records) {
         if (record.uuid == uuid) {
             return &record;
@@ -35,7 +35,7 @@ auto up::AssetLibrary::findRecordByUuid(UUID uuid) const noexcept -> Imported co
     return nullptr;
 }
 
-auto up::AssetLibrary::createLogicalAssetId(UUID uuid, string_view logicalName) noexcept -> AssetId {
+auto up::AssetLibrary::createLogicalAssetId(UUID const& uuid, string_view logicalName) noexcept -> AssetId {
     uint64 hash = hash_value(uuid);
     if (!logicalName.empty()) {
         hash = hash_combine(hash, hash_value(logicalName));

--- a/source/libtools/private/asset_library.cpp
+++ b/source/libtools/private/asset_library.cpp
@@ -179,10 +179,9 @@ void up::AssetLibrary::generateManifest(erased_writer writer) const {
     format_to(writer, ".version={}\n", ResourceManifest::version);
     format_to(
         writer,
-        ":{}|{}|{}|{}|{}|{}\n",
+        ":{}|{}|{}|{}|{}\n",
         ResourceManifest::columnUuid,
         ResourceManifest::columnLogicalId,
-        ResourceManifest::columnLogicalName,
         ResourceManifest::columnContentType,
         ResourceManifest::columnContentHash,
         ResourceManifest::columnDebugName);
@@ -200,10 +199,9 @@ void up::AssetLibrary::generateManifest(erased_writer writer) const {
 
             format_to(
                 writer,
-                "{}|{:016X}|{:016X}|{}|{:016X}|{}\n",
+                "{}|{:016X}|{}|{:016X}|{}\n",
                 record.uuid,
                 output.logicalAssetId,
-                hash_value(output.name),
                 output.type,
                 output.contentHash,
                 fullName);

--- a/source/libtools/private/importer_context.cpp
+++ b/source/libtools/private/importer_context.cpp
@@ -9,9 +9,11 @@ up::ImporterContext::ImporterContext(
     zstring_view sourceFilePath,
     zstring_view sourceFolderPath,
     zstring_view destinationFolderPath,
+    Importer const* importer,
     ImporterConfig const& config,
     Logger& logger)
-    : _config(&config)
+    : _importer(importer)
+    , _config(&config)
     , _sourceFilePath(sourceFilePath)
     , _sourceFolderPath(sourceFolderPath)
     , _destinationFolderPath(destinationFolderPath)

--- a/source/libtools/public/potato/tools/asset_library.h
+++ b/source/libtools/public/potato/tools/asset_library.h
@@ -7,6 +7,7 @@
 #include "potato/format/erased.h"
 #include "potato/posql/posql.h"
 #include "potato/runtime/asset.h"
+#include "potato/runtime/uuid.h"
 #include "potato/spud/string.h"
 #include "potato/spud/string_view.h"
 #include "potato/spud/unique_resource.h"
@@ -31,7 +32,7 @@ namespace up {
         };
 
         struct Imported {
-            AssetId assetId = AssetId::Invalid;
+            UUID uuid;
             string sourcePath;
             string importerName;
             uint64 importerRevision = 0;
@@ -42,7 +43,7 @@ namespace up {
         };
 
         static constexpr zstring_view typeName = "potato.asset.library"_zsv;
-        static constexpr int version = 12;
+        static constexpr int version = 13;
 
         AssetLibrary() = default;
         UP_TOOLS_API ~AssetLibrary();
@@ -50,10 +51,12 @@ namespace up {
         AssetLibrary(AssetLibrary const&) = delete;
         AssetLibrary& operator=(AssetLibrary const&) = delete;
 
-        UP_TOOLS_API auto pathToAssetId(string_view path) const -> AssetId;
-        UP_TOOLS_API auto assetIdToPath(AssetId assetId) const -> string_view;
+        UP_TOOLS_API auto pathToUuid(string_view path) const noexcept -> UUID;
+        UP_TOOLS_API auto uuidToPath(UUID uuid) const noexcept -> string_view;
 
-        UP_TOOLS_API Imported const* findRecord(AssetId assetId) const;
+        static UP_TOOLS_API AssetId createLogicalAssetId(UUID uuid, string_view logicalName) noexcept;
+
+        UP_TOOLS_API Imported const* findRecordByUuid(UUID uuid) const noexcept;
 
         UP_TOOLS_API bool insertRecord(Imported record);
 

--- a/source/libtools/public/potato/tools/asset_library.h
+++ b/source/libtools/public/potato/tools/asset_library.h
@@ -52,11 +52,11 @@ namespace up {
         AssetLibrary& operator=(AssetLibrary const&) = delete;
 
         UP_TOOLS_API auto pathToUuid(string_view path) const noexcept -> UUID;
-        UP_TOOLS_API auto uuidToPath(UUID uuid) const noexcept -> string_view;
+        UP_TOOLS_API auto uuidToPath(UUID const& uuid) const noexcept -> string_view;
 
-        static UP_TOOLS_API AssetId createLogicalAssetId(UUID uuid, string_view logicalName) noexcept;
+        static UP_TOOLS_API AssetId createLogicalAssetId(UUID const& uuid, string_view logicalName) noexcept;
 
-        UP_TOOLS_API Imported const* findRecordByUuid(UUID uuid) const noexcept;
+        UP_TOOLS_API Imported const* findRecordByUuid(UUID const& uuid) const noexcept;
 
         UP_TOOLS_API bool insertRecord(Imported record);
 

--- a/source/libtools/public/potato/tools/importer.h
+++ b/source/libtools/public/potato/tools/importer.h
@@ -28,7 +28,7 @@ namespace up {
 
         virtual reflex::TypeInfo const& configType() const;
 
-        virtual string_view generateSettings(ImporterContext& ctd) = 0;
+        virtual string_view generateSettings(ImporterContext& ctd) const = 0;
 
         virtual string_view name() const noexcept = 0;
         virtual uint64 revision() const noexcept = 0;

--- a/source/libtools/public/potato/tools/importer_context.h
+++ b/source/libtools/public/potato/tools/importer_context.h
@@ -4,6 +4,7 @@
 
 #include "_export.h"
 
+#include "potato/runtime/uuid.h"
 #include "potato/spud/box.h"
 #include "potato/spud/concepts.h"
 #include "potato/spud/std_iostream.h"
@@ -15,6 +16,7 @@
 
 namespace up {
     class Logger;
+    class Importer;
     struct ImporterConfig;
 
     class ImporterContext {
@@ -29,6 +31,7 @@ namespace up {
             zstring_view sourceFilePath,
             zstring_view sourceFolderPath,
             zstring_view destinationFolderPath,
+            Importer const* importer,
             ImporterConfig const& config,
             Logger& logger);
         UP_TOOLS_API ~ImporterContext();
@@ -44,8 +47,13 @@ namespace up {
         void addOutput(string logicalAsset, string path, string type);
         void addMainOutput(string path, string type);
 
+        Importer const* importer() const noexcept { return _importer; }
+
         view<string> sourceDependencies() const noexcept { return _sourceDependencies; }
         view<Output> outputs() const noexcept { return _outputs; }
+
+        UUID const& uuid() const noexcept { return _uuid; }
+        void setUuid(UUID uuid) noexcept { _uuid = std::move(uuid); }
 
         Logger& logger() noexcept { return _logger; }
 
@@ -56,10 +64,12 @@ namespace up {
         }
 
     private:
+        Importer const* _importer = nullptr;
         ImporterConfig const* _config = nullptr;
         zstring_view _sourceFilePath;
         zstring_view _sourceFolderPath;
         zstring_view _destinationFolderPath;
+        UUID _uuid;
 
         vector<string> _sourceDependencies;
         vector<Output> _outputs;

--- a/source/libtools/public/potato/tools/importer_context.h
+++ b/source/libtools/public/potato/tools/importer_context.h
@@ -53,7 +53,7 @@ namespace up {
         view<Output> outputs() const noexcept { return _outputs; }
 
         UUID const& uuid() const noexcept { return _uuid; }
-        void setUuid(UUID uuid) noexcept { _uuid = std::move(uuid); }
+        void setUuid(UUID const& uuid) noexcept { _uuid = uuid; }
 
         Logger& logger() noexcept { return _logger; }
 

--- a/source/libtools/public/potato/tools/importers/copy_importer.h
+++ b/source/libtools/public/potato/tools/importers/copy_importer.h
@@ -15,7 +15,7 @@ namespace up {
         ~CopyImporter() override;
 
         bool import(ImporterContext& ctx) override;
-        string_view generateSettings(ImporterContext& ctd) override { return {}; }
+        string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         reflex::TypeInfo const& configType() const noexcept override;
 

--- a/source/libtools/public/potato/tools/importers/hlsl_importer.h
+++ b/source/libtools/public/potato/tools/importers/hlsl_importer.h
@@ -11,7 +11,7 @@ namespace up {
         ~HlslImporter() override;
 
         bool import(ImporterContext& ctx) override;
-        string_view generateSettings(ImporterContext& ctd) override { return {}; }
+        string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         string_view name() const noexcept override { return "hlsl"; }
         uint64 revision() const noexcept override { return 9; }

--- a/source/libtools/public/potato/tools/importers/ignore_importer.h
+++ b/source/libtools/public/potato/tools/importers/ignore_importer.h
@@ -10,7 +10,7 @@ namespace up {
         IgnoreImporter() = default;
 
         bool import(ImporterContext& ctx) override { return true; }
-        string_view generateSettings(ImporterContext& ctd) override { return {}; }
+        string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         string_view name() const noexcept override { return "ignore"; }
         uint64 revision() const noexcept override { return 0; }

--- a/source/libtools/public/potato/tools/importers/json_importer.h
+++ b/source/libtools/public/potato/tools/importers/json_importer.h
@@ -15,7 +15,7 @@ namespace up {
         ~JsonImporter() override;
 
         bool import(ImporterContext& ctx) override;
-        string_view generateSettings(ImporterContext& ctd) override { return {}; }
+        string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         reflex::TypeInfo const& configType() const noexcept override;
 

--- a/source/libtools/public/potato/tools/importers/material_importer.h
+++ b/source/libtools/public/potato/tools/importers/material_importer.h
@@ -14,6 +14,6 @@ namespace up {
         string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         string_view name() const noexcept override { return "material"; }
-        uint64 revision() const noexcept override { return 1; }
+        uint64 revision() const noexcept override { return 2; }
     };
 } // namespace up

--- a/source/libtools/public/potato/tools/importers/material_importer.h
+++ b/source/libtools/public/potato/tools/importers/material_importer.h
@@ -11,7 +11,7 @@ namespace up {
         ~MaterialImporter() override;
 
         bool import(ImporterContext& ctx) override;
-        string_view generateSettings(ImporterContext& ctd) override { return {}; }
+        string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         string_view name() const noexcept override { return "material"; }
         uint64 revision() const noexcept override { return 1; }

--- a/source/libtools/public/potato/tools/importers/model_importer.h
+++ b/source/libtools/public/potato/tools/importers/model_importer.h
@@ -11,7 +11,7 @@ namespace up {
         ~ModelImporter() override;
 
         bool import(ImporterContext& ctx) override;
-        string_view generateSettings(ImporterContext& ctd) override { return {}; }
+        string_view generateSettings(ImporterContext& ctd) const override { return {}; }
 
         string_view name() const noexcept override { return "model"; }
         uint64 revision() const noexcept override { return 5; }


### PR DESCRIPTION
Closes #228 

- Replaces the use of the hashed file path as the primary source asset id
- Replaces use of hashed file path + logical name with hashed uuid + logical name for logical id

Todo:
- [x] Ensure loading assets still works at run-time
- [x] Plumb use of UUID through editor for opening documents
- [x] Plumb use of UUID through files like materials for references other resources