### PR TITLE
Enable more warnings in MSVC

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           CXXFLAGS: /FC
         run: |
           mkdir build
-          cmake -S . -B build -G Ninja -DUP_CXXFLAGS:STRING="/W3 /WX /w34295 /w34189 /w34100" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DBUILD_SHARED_LIBS=YES
+          cmake -S . -B build -G Ninja -DUP_CXXFLAGS:STRING="/W3 /WX /w34295 /w34189" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DBUILD_SHARED_LIBS=YES
       - name: Build
         run: cmake --build build --parallel -- -k 0 -v
       - name: Test
@@ -66,7 +66,7 @@ jobs:
           - cxx: g++-10
             cc: gcc-10
             cxxflags: -fcoroutines
-            warnings: -Wall -Werror -Wno-volatile -Wno-maybe-uninitialized -Wnodeprecated-enum-enum-conversion # GLM triggers volatile, Tracy triggers maybe-unitialized, imgui triggers enum-enum-conversion
+            warnings: -Wall -Werror -Wno-volatile -Wno-maybe-uninitialized -Wno-deprecated-enum-enum-conversion # GLM triggers volatile, Tracy triggers maybe-unitialized, imgui triggers enum-enum-conversion
             packages: g++-10 gcc-10 libstdc++-10-dev
           - cxx: clang++-10
             cc: clang-10

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
           CXXFLAGS: /FC
         run: |
           mkdir build
-          cmake -S . -B build -G Ninja -DUP_CXXFLAGS:STRING="/W3 /WX" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DBUILD_SHARED_LIBS=YES
+          cmake -S . -B build -G Ninja -DUP_CXXFLAGS:STRING="/W3 /WX /w34295 /w34189 /w34100" -DCMAKE_BUILD_TYPE:STRING=${{ matrix.config }} -DBUILD_SHARED_LIBS=YES
       - name: Build
         run: cmake --build build --parallel -- -k 0 -v
       - name: Test
@@ -66,7 +66,7 @@ jobs:
           - cxx: g++-10
             cc: gcc-10
             cxxflags: -fcoroutines
-            warnings: -Wall -Werror -Wno-volatile -Wno-maybe-uninitialized # GLM triggers volatile, Tracy triggers maybe-unitialized
+            warnings: -Wall -Werror -Wno-volatile -Wno-maybe-uninitialized -Wnodeprecated-enum-enum-conversion # GLM triggers volatile, Tracy triggers maybe-unitialized, imgui triggers enum-enum-conversion
             packages: g++-10 gcc-10 libstdc++-10-dev
           - cxx: clang++-10
             cc: clang-10

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -8,7 +8,7 @@
       "environment": "up_msvc",
       "namespace": "up_msvc",
       "CXXFLAGS": "/FC /Zi",
-      "UP_CXXFLAGS": "/W3 /WX"
+      "UP_CXXFLAGS": "/W3 /WX /w34295 /w34189 /w34100"
     },
     {
       "environment": "up_msvc_debug",
@@ -44,6 +44,10 @@
           "value": "${up_msvc_debug.CXXFLAGS}"
         },
         {
+          "name": "UP_CXXFLAGS",
+          "value": "${up_msvc.UP_CXXFLAGS}"
+        },
+        {
           "name": "BUILD_SHARED_LIBS",
           "value": "YES",
           "type": "BOOL"
@@ -70,6 +74,10 @@
           "value": "${up_msvc_debug.CXXFLAGS}"
         },
         {
+          "name": "UP_CXXFLAGS",
+          "value": "${up_msvc.UP_CXXFLAGS}"
+        },
+        {
           "name": "CMAKE_EXPORT_COMPILE_COMMANDS",
           "value": "ON",
           "type": "BOOL"
@@ -89,6 +97,10 @@
         {
           "name": "CMAKE_CXX_FLAGS_RELEASE",
           "value": "${up_msvc_release.CXXFLAGS}"
+        },
+        {
+          "name": "UP_CXXFLAGS",
+          "value": "${up_msvc.UP_CXXFLAGS}"
         },
         {
           "name": "CMAKE_EXPORT_COMPILE_COMMANDS",

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -8,7 +8,7 @@
       "environment": "up_msvc",
       "namespace": "up_msvc",
       "CXXFLAGS": "/FC /Zi",
-      "UP_CXXFLAGS": "/W3 /WX /w34295 /w34189 /w34100"
+      "UP_CXXFLAGS": "/W3 /WX /w34295 /w34189"
     },
     {
       "environment": "up_msvc_debug",

--- a/source/libformat/public/potato/format/_detail/format_impl.h
+++ b/source/libformat/public/potato/format/_detail/format_impl.h
@@ -18,7 +18,6 @@ namespace up::_detail {
     };
 
     constexpr format_impl_inner_result format_impl_inner(
-        char const*& begin,
         char const* const end,
         char const*& iter,
         unsigned next_index) noexcept {
@@ -93,7 +92,7 @@ namespace up::_detail {
                 continue;
             }
 
-            auto const [result, index, spec_string] = format_impl_inner(begin, end, iter, next_index);
+            auto const [result, index, spec_string] = format_impl_inner(end, iter, next_index);
             if (result != format_result::success) {
                 return result;
             }


### PR DESCRIPTION
Enable more warnings in MSVC builds to help catch the kinds of things that clang-tidy dislikes.

/w34295 -- https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4295?view=msvc-160
/w34189 -- https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4189?view=msvc-160