### PR TITLE
Open correct editor for asset

### DIFF
--- a/source/bin_shell/private/shell_app.cpp
+++ b/source/bin_shell/private/shell_app.cpp
@@ -662,7 +662,7 @@ void up::shell::ShellApp::_openAssetEditor(UUID const& uuid) {
 
     zstring_view const editor = _assetEditService.findInfoForAssetTypeHash(assetTypeHash).editor;
     if (!editor.empty()) {
-        _openEditorForDocument(SceneEditor::editorName, assetPath);
+        _openEditorForDocument(editor, assetPath);
     }
     else {
         if (!desktop::openInExternalEditor(assetPath)) {


### PR DESCRIPTION
Was hard-coded to only opening the scene editor