### PR TITLE
Don't treat a previous build of uv.lib in our output directory as a "…

### DIFF
--- a/external/assimp_win64.cmake
+++ b/external/assimp_win64.cmake
@@ -7,6 +7,6 @@ if(WIN32)
         FetchContent_Populate(assimp_win64_sdk)
 
         set(ASSIMP_ROOT_DIR ${assimp_win64_sdk_SOURCE_DIR} CACHE PATH "local AssImp path" FORCE)
-        find_package(Assimp REQUIRED)
+        find_package(Assimp REQUIRED QUIET)
     endif()
 endif()

--- a/external/libuv.cmake
+++ b/external/libuv.cmake
@@ -3,7 +3,10 @@ include(config.cmake)
 find_library(libuv_LIBRARY NAMES uv libuv)
 mark_as_advanced(libuv_LIBRARY)
 
-if (NOT libuv_LIBRARY)
+find_path(libuv_INCLUDE_DIR NAMES uv.h)
+mark_as_advanced(libuv_INCLUDE_DIR)
+
+if (NOT libuv_LIBRARY OR NOT libuv_INCLUDE_DIR)
     FetchContent_Populate(libuv)
     add_subdirectory(${libuv_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR}/libuv EXCLUDE_FROM_ALL)
 
@@ -19,8 +22,7 @@ if (NOT libuv_LIBRARY)
         )
     endif()
 else()
-    find_path(libuv_INCLUDE_DIR NAMES uv.h)
-    mark_as_advanced(libuv_INCLUDE_DIR)
+    message(STATUS "Using system libuv ${libuv_LIBRARY}")
 
     add_library(uv INTERFACE)
     target_link_libraries(uv INTERFACE ${libuv_LIBRARY})

--- a/external/sdl2_vc.cmake
+++ b/external/sdl2_vc.cmake
@@ -7,6 +7,6 @@ if(WIN32)
         FetchContent_Populate(sdl2_vc_sdk)
 
         set(SDL2_PATH ${sdl2_vc_sdk_SOURCE_DIR} CACHE PATH "local SDL2 path" FORCE)
-        find_package(SDL2 REQUIRED)
+        find_package(SDL2 REQUIRED QUIET)
     endif()
 endif()


### PR DESCRIPTION
…system" uv install