### PR TITLE
Add clang-tidy to presets for VS

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,12 @@
         "FETCHCONTENT_QUIET": true
       },
       "binaryDir": "${sourceDir}/out/${presetName}",
-      "generator": "Ninja"
+      "generator": "Ninja",
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "enableClangTidyCodeAnalysis": true
+        }
+      }
     },
     {
       "name": "msvc",


### PR DESCRIPTION
Todo:

- [ ] Get tidy to run as 64-bit mode (it treats `size_t` as 32-bit currently; there's a VS issue for this that was closed; this case is probably different)
- [ ] Get tidy to only execute on our files (VS presets is project-wide and can't be limited to a directly, so we'll have to do it via dummy .clang-tidy files)