### PR TITLE
Import Marcin's D3D12 code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules" "${CMAKE_CURRE
 option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(UP_BUILD_DOCS "Build documentation" OFF)
 option(UP_BUILD_D3D11 "Build D3D11 backend" ${WIN32})
+option(UP_BUILD_D3D12 "Build D3D12 backend" OFF)
 
 set(UP_CLANG_TIDY "" CACHE PATH "Path to clang-tidy")
 

--- a/depends.cmake
+++ b/depends.cmake
@@ -86,3 +86,12 @@ up_require(nanofmt
     GIT_REPOSITORY git://github.com/seanmiddleditch/nanofmt.git
     GIT_COMMIT b979434328e1f0ec5e6ef977bc59a251c4bc9dfc
 )
+if(UP_BUILD_D3D12)
+    up_require(dx12memalloc
+        GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/D3D12MemoryAllocator.git
+        GIT_COMMIT 23e4d91f66397b49e84115e5d1b91fd64c3df24a
+        CMAKE_FILE dx12memalloc.cmake
+    )
+endif()
+
+

--- a/external/dx12memalloc.cmake
+++ b/external/dx12memalloc.cmake
@@ -1,0 +1,13 @@
+FetchContent_Populate(dx12memalloc)
+add_library(dx12memalloc STATIC)
+target_include_directories(dx12memalloc
+    PUBLIC "${dx12memalloc_SOURCE_DIR}/include"
+    PRIVATE "${dx12memalloc_SOURCE_DIR}/src"
+)
+
+target_sources(dx12memalloc PRIVATE
+    "${dx12memalloc_SOURCE_DIR}/src/Common.cpp"
+    "${dx12memalloc_SOURCE_DIR}/src/D3D12MemAlloc.cpp"
+)
+set_target_properties(dx12memalloc PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+target_compile_definitions(dx12memalloc PUBLIC)

--- a/potato/librender/CMakeLists.txt
+++ b/potato/librender/CMakeLists.txt
@@ -80,6 +80,31 @@ if(UP_BUILD_D3D11)
     set_target_properties(potato_librender PROPERTIES UP_GPU_ENABLE_D3D11 ON)
 endif()
 
+if(UP_BUILD_D3D12)
+    find_library(DXGI_PATH dxgi REQUIRED)
+    find_library(D3D12_PATH d3d12 REQUIRED)
+
+    add_subdirectory("source/d3d12_backend")
+
+    up_compile_shader(potato_librender
+        PROFILE vs_5_1
+        HLSL
+            "data/shaders/debug.hlsl"
+            "data/shaders/imgui.hlsl"
+    )
+    up_compile_shader(potato_librender
+        PROFILE ps_5_1
+        HLSL
+            "data/shaders/debug.hlsl"
+            "data/shaders/imgui.hlsl"
+    )
+
+    target_link_libraries(potato_librender PRIVATE ${D3D12_PATH} ${DXGI_PATH} dx12memalloc)
+    target_sources(potato_librender PRIVATE ${UP_GPU_D3D12_SOURCES})
+    target_compile_definitions(potato_librender PUBLIC UP_GPU_ENABLE_D3D12=1 UP_GPU_ENABLE_D3D=1)
+    set_target_properties(potato_librender PROPERTIES UP_GPU_ENABLE_D3D12 ON)
+endif()
+
 add_executable(potato_librender_test)
 target_sources(potato_librender_test PRIVATE
     "tests/main.cpp"

--- a/potato/librender/source/d3d12_backend/CMakeLists.txt
+++ b/potato/librender/source/d3d12_backend/CMakeLists.txt
@@ -1,0 +1,14 @@
+target_sources(potato_librender PRIVATE
+    "d3d12_command_list.cpp"
+    "d3d12_buffer.cpp"
+    "d3d12_device.cpp"
+    "d3d12_factory.cpp"
+    "d3d12_resource_view.cpp"
+    "d3d12_sampler.cpp"
+    "d3d12_swap_chain.cpp"
+    "d3d12_platform.cpp"
+    "d3d12_pipeline_state.cpp"
+    "d3d12_root_signature.cpp"
+    "d3d12_texture.cpp"
+    "d3d12_desc_heap.cpp"
+)

--- a/potato/librender/source/d3d12_backend/d3d12_buffer.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_buffer.cpp
@@ -8,12 +8,9 @@
 
 #include <D3D12MemAlloc.h>
 
-up::d3d12::BufferD3D12::BufferD3D12() noexcept
-{}
+up::d3d12::BufferD3D12::BufferD3D12() noexcept { }
 
-auto up::d3d12::BufferD3D12::create(D3D12MA::Allocator& allocator, GpuBufferType type, uint64 size)
-    -> bool {
-
+auto up::d3d12::BufferD3D12::create(D3D12MA::Allocator& allocator, GpuBufferType type, uint64 size) -> bool {
     // const buffers have to be multiples of 256
     if (type == GpuBufferType::Constant) {
         size = 256 * ((size / 256) + 1);
@@ -36,10 +33,10 @@ auto up::d3d12::BufferD3D12::create(D3D12MA::Allocator& allocator, GpuBufferType
     allocator.CreateResource(
         &vertexBufferAllocDesc,
         &vertexBufferResourceDesc,
-        D3D12_RESOURCE_STATE_GENERIC_READ, 
-        nullptr, 
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        nullptr,
         out_ptr(_allocation),
-        __uuidof(ID3D12Resource), 
+        __uuidof(ID3D12Resource),
         out_ptr(_buffer));
 
     _size = size;

--- a/potato/librender/source/d3d12_backend/d3d12_buffer.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_buffer.cpp
@@ -1,0 +1,49 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_buffer.h"
+#include "d3d12_desc_heap.h"
+
+#include "potato/spud/int_types.h"
+#include "potato/spud/out_ptr.h"
+
+#include <D3D12MemAlloc.h>
+
+up::d3d12::BufferD3D12::BufferD3D12() noexcept
+{}
+
+auto up::d3d12::BufferD3D12::create(D3D12MA::Allocator& allocator, GpuBufferType type, uint64 size)
+    -> bool {
+
+    // const buffers have to be multiples of 256
+    if (type == GpuBufferType::Constant) {
+        size = 256 * ((size / 256) + 1);
+    }
+    D3D12MA::ALLOCATION_DESC vertexBufferAllocDesc = {};
+    vertexBufferAllocDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+    D3D12_RESOURCE_DESC vertexBufferResourceDesc = {};
+    vertexBufferResourceDesc.Dimension = D3D12_RESOURCE_DIMENSION_BUFFER;
+    vertexBufferResourceDesc.Alignment = 0;
+    vertexBufferResourceDesc.Width = size;
+    vertexBufferResourceDesc.Height = 1;
+    vertexBufferResourceDesc.DepthOrArraySize = 1;
+    vertexBufferResourceDesc.MipLevels = 1;
+    vertexBufferResourceDesc.Format = DXGI_FORMAT_UNKNOWN;
+    vertexBufferResourceDesc.SampleDesc.Count = 1;
+    vertexBufferResourceDesc.SampleDesc.Quality = 0;
+    vertexBufferResourceDesc.Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+    vertexBufferResourceDesc.Flags = D3D12_RESOURCE_FLAG_NONE;
+
+    allocator.CreateResource(
+        &vertexBufferAllocDesc,
+        &vertexBufferResourceDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ, 
+        nullptr, 
+        out_ptr(_allocation),
+        __uuidof(ID3D12Resource), 
+        out_ptr(_buffer));
+
+    _size = size;
+    _type = type;
+
+    return true;
+};

--- a/potato/librender/source/d3d12_backend/d3d12_buffer.h
+++ b/potato/librender/source/d3d12_backend/d3d12_buffer.h
@@ -1,0 +1,40 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_buffer.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+
+#include <D3D12MemAlloc.h>
+
+namespace up::d3d12 {
+    class DescriptorHeapD3D12;
+
+    class BufferD3D12 final : public GpuBuffer {
+    public:
+        BufferD3D12() noexcept;
+        ~BufferD3D12() override = default;
+
+        bool create(D3D12MA::Allocator& allocator, GpuBufferType type, uint64 size);
+
+        GpuBufferType type() const noexcept override { return _type; }
+        uint64 size() const noexcept override { return _size; }
+
+        ID3DResourcePtr const& buffer() const noexcept { return _buffer; }
+        D3D12MA::Allocation* const& alloc() const noexcept { return _allocation.get(); }
+
+        D3D12_GPU_DESCRIPTOR_HANDLE getDesc() const { return _desc; }
+        void setDesc(D3D12_GPU_DESCRIPTOR_HANDLE desc) { _desc = desc; }
+
+    private:
+        GpuBufferType _type;
+        uint64 _size;
+        ID3DResourcePtr _buffer;
+        com_ptr<D3D12MA::Allocation> _allocation;
+
+        D3D12_GPU_DESCRIPTOR_HANDLE _desc;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_command_list.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_command_list.cpp
@@ -13,7 +13,7 @@
 #include "potato/spud/int_types.h"
 #include "potato/spud/out_ptr.h"
 
-up::d3d12::CommandListD3D12::CommandListD3D12() {}
+up::d3d12::CommandListD3D12::CommandListD3D12() { }
 
 up::d3d12::CommandListD3D12::~CommandListD3D12() = default;
 
@@ -190,9 +190,7 @@ void up::d3d12::CommandListD3D12::start(GpuPipelineState* pipelineState) {
 }
 
 void up::d3d12::CommandListD3D12::finish() {
-    if (FAILED(_commandList->Close())) {
-
-    }
+    if (FAILED(_commandList->Close())) { }
 }
 
 void up::d3d12::CommandListD3D12::clear(GpuPipelineState* pipelineState) {
@@ -241,4 +239,4 @@ void up::d3d12::CommandListD3D12::update(GpuBuffer* buffer, span<up::byte const>
     unmap(buffer, target);
 }
 
-void up::d3d12::CommandListD3D12::_flushBindings() {}
+void up::d3d12::CommandListD3D12::_flushBindings() { }

--- a/potato/librender/source/d3d12_backend/d3d12_command_list.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_command_list.cpp
@@ -1,0 +1,244 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_command_list.h"
+#include "d3d12_buffer.h"
+#include "d3d12_desc_heap.h"
+#include "d3d12_pipeline_state.h"
+#include "d3d12_platform.h"
+#include "d3d12_resource_view.h"
+#include "d3d12_sampler.h"
+#include "d3d12_texture.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/spud/int_types.h"
+#include "potato/spud/out_ptr.h"
+
+up::d3d12::CommandListD3D12::CommandListD3D12() {}
+
+up::d3d12::CommandListD3D12::~CommandListD3D12() = default;
+
+auto up::d3d12::CommandListD3D12::createCommandList(
+    ID3D12Device* device,
+    GpuPipelineState* pipelineState,
+    D3D12_COMMAND_LIST_TYPE type) -> box<CommandListD3D12> {
+    auto cl = new_box<CommandListD3D12>();
+    auto state = pipelineState != nullptr ? static_cast<PipelineStateD3D12*>(pipelineState)->state() : nullptr;
+    cl->create(device, state, type);
+    return std::move(cl);
+}
+
+auto up::d3d12::CommandListD3D12::create(
+    ID3D12Device* device,
+    ID3D12PipelineState* pipelineState,
+    D3D12_COMMAND_LIST_TYPE type) -> bool {
+    device->CreateCommandAllocator(type, __uuidof(ID3D12CommandAllocator), out_ptr(_commandAllocator));
+
+    _commandAllocator->SetName(L"CommandAllocator");
+
+    HRESULT hr = device->CreateCommandList(
+        0,
+        type,
+        _commandAllocator.get(),
+        pipelineState,
+        __uuidof(ID3D12GraphicsCommandList),
+        out_ptr(_commandList));
+
+    if (FAILED(hr)) {
+        return false;
+    }
+    _commandList->SetName(L"CommandList");
+    _commandList->Close();
+    return true;
+}
+
+void up::d3d12::CommandListD3D12::setPipelineState(GpuPipelineState* state) {
+    UP_ASSERT(state != nullptr);
+    _pipeline = static_cast<PipelineStateD3D12*>(state);
+    _pipeline->bindPipeline(_commandList.get());
+}
+
+void up::d3d12::CommandListD3D12::bindRenderTarget(up::uint32 index, GpuResourceView* view) {
+    UP_ASSERT(index < maxRenderTargetBindings);
+    auto srv = static_cast<ResourceViewD3D12*>(view);
+    auto desc = srv->getCpuDesc();
+    _commandList->OMSetRenderTargets(1, &desc, FALSE, nullptr);
+}
+
+void up::d3d12::CommandListD3D12::bindDepthStencil(GpuResourceView* view) {
+    auto dsv = static_cast<ResourceViewD3D12*>(view);
+    UP_ASSERT(dsv->type() == GpuViewType::DSV);
+}
+
+void up::d3d12::CommandListD3D12::bindIndexBuffer(GpuBuffer* buffer, GpuIndexFormat indexType, up::uint32 offset) {
+    UP_ASSERT(buffer != nullptr);
+    UP_ASSERT(buffer->type() == GpuBufferType::Index);
+
+    auto impl = static_cast<BufferD3D12*>(buffer);
+    D3D12_INDEX_BUFFER_VIEW view;
+    view.BufferLocation = impl->buffer()->GetGPUVirtualAddress() + offset;
+    view.Format = toNative(indexType);
+    view.SizeInBytes = static_cast<UINT>(impl->size());
+
+    _commandList->IASetIndexBuffer(&view);
+}
+
+void up::d3d12::CommandListD3D12::bindVertexBuffer(
+    up::uint32 slot,
+    GpuBuffer* buffer,
+    up::uint64 stride,
+    up::uint64 offset) {
+    UP_ASSERT(buffer != nullptr);
+    UP_ASSERT(buffer->type() == GpuBufferType::Vertex);
+
+    auto impl = static_cast<BufferD3D12*>(buffer);
+    D3D12_VERTEX_BUFFER_VIEW view;
+    view.BufferLocation = impl->buffer()->GetGPUVirtualAddress() + offset;
+    view.StrideInBytes = static_cast<UINT>(stride);
+    view.SizeInBytes = static_cast<UINT>(impl->size());
+
+    _commandList->IASetVertexBuffers(slot, 1, &view);
+}
+
+void up::d3d12::CommandListD3D12::bindConstantBuffer(up::uint32 slot, GpuBuffer* buffer, GpuShaderStage stage) {
+    UP_ASSERT(buffer != nullptr);
+    UP_ASSERT(buffer->type() == GpuBufferType::Constant);
+
+    auto cb = static_cast<BufferD3D12*>(buffer);
+
+    _pipeline->bindConstBuffer(_commandList.get(), slot, cb->buffer()->GetGPUVirtualAddress());
+}
+
+void up::d3d12::CommandListD3D12::bindConstantValues(up::uint32 count, float* values, GpuShaderStage stage) {
+    UP_ASSERT(values != nullptr);
+    _pipeline->bindConstValues(_commandList.get(), count, values);
+}
+
+void up::d3d12::CommandListD3D12::bindShaderResource(up::uint32 slot, GpuResourceView* view, GpuShaderStage stage) {
+    UP_ASSERT(view != nullptr);
+}
+
+void up::d3d12::CommandListD3D12::bindTexture(
+    up::uint32 slot,
+    GpuResourceView* view,
+    GpuSampler* sampler,
+    GpuShaderStage stage) {
+    UP_ASSERT(view != nullptr);
+    UP_ASSERT(sampler != nullptr);
+
+    auto srv = static_cast<ResourceViewD3D12*>(view);
+    auto s = static_cast<SamplerD3D12*>(sampler);
+
+    _pipeline->bindTexture(_commandList.get(), slot, srv->getGpuDesc(), s->desc());
+}
+
+void up::d3d12::CommandListD3D12::setPrimitiveTopology(GpuPrimitiveTopology topology) {
+    D3D12_PRIMITIVE_TOPOLOGY primitive = D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST; // default
+    switch (topology) {
+        case GpuPrimitiveTopology::Lines:
+            primitive = D3D_PRIMITIVE_TOPOLOGY_LINELIST;
+            break;
+    }
+    _commandList->IASetPrimitiveTopology(primitive);
+}
+
+void up::d3d12::CommandListD3D12::setViewport(GpuViewportDesc const& viewport) {
+    D3D12_VIEWPORT d3d12Viewport;
+    d3d12Viewport.TopLeftX = viewport.leftX;
+    d3d12Viewport.TopLeftY = viewport.topY;
+    d3d12Viewport.Width = viewport.width;
+    d3d12Viewport.Height = viewport.height;
+    d3d12Viewport.MinDepth = viewport.minDepth;
+    d3d12Viewport.MaxDepth = viewport.maxDepth;
+    _commandList->RSSetViewports(1, &d3d12Viewport);
+}
+
+void up::d3d12::CommandListD3D12::setClipRect(GpuClipRect rect) {
+    D3D12_RECT clipRect;
+    clipRect.left = static_cast<LONG>(rect.left);
+    clipRect.top = static_cast<LONG>(rect.top);
+    clipRect.right = static_cast<LONG>(rect.right);
+    clipRect.bottom = static_cast<LONG>(rect.bottom);
+    _commandList->RSSetScissorRects(1, &clipRect);
+}
+
+void up::d3d12::CommandListD3D12::draw(up::uint32 vertexCount, up::uint32 firstVertex) {
+    _commandList->DrawInstanced(vertexCount, 1, firstVertex, 0);
+}
+
+void up::d3d12::CommandListD3D12::drawIndexed(up::uint32 indexCount, up::uint32 firstIndex, up::uint32 baseIndex) {
+    _commandList->DrawIndexedInstanced(indexCount, 1, firstIndex, baseIndex, 0);
+}
+
+void up::d3d12::CommandListD3D12::clearRenderTarget(GpuResourceView* view, glm::vec4 color) {
+    UP_ASSERT(view != nullptr);
+    auto rtv = static_cast<ResourceViewD3D12*>(view);
+
+    float clearColor[4] = {color.x, color.y, color.z, color.w};
+    _commandList->ClearRenderTargetView(rtv->getCpuDesc(), clearColor, 0, nullptr);
+}
+
+void up::d3d12::CommandListD3D12::clearDepthStencil(GpuResourceView* view) {
+    UP_ASSERT(view != nullptr);
+    auto dsv = static_cast<ResourceViewD3D12*>(view);
+    _commandList->ClearDepthStencilView(dsv->getCpuDesc(), D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+}
+
+void up::d3d12::CommandListD3D12::start(GpuPipelineState* pipelineState) {
+    auto ps = static_cast<PipelineStateD3D12*>(pipelineState);
+    _commandAllocator->Reset();
+    _commandList->Reset(_commandAllocator.get(), ps ? ps->state() : nullptr);
+}
+
+void up::d3d12::CommandListD3D12::finish() {
+    if (FAILED(_commandList->Close())) {
+
+    }
+}
+
+void up::d3d12::CommandListD3D12::clear(GpuPipelineState* pipelineState) {
+    auto ps = static_cast<PipelineStateD3D12*>(pipelineState);
+    _commandList->ClearState(ps ? ps->state() : nullptr);
+    _commandList->RSSetScissorRects(0, nullptr);
+    if (pipelineState != nullptr) {
+        setPipelineState(pipelineState);
+    }
+}
+
+auto up::d3d12::CommandListD3D12::map(GpuBuffer* buffer, up::uint64 size, up::uint64 offset) -> span<up::byte> {
+    if (buffer == nullptr) {
+        return {};
+    }
+    auto d3dBuffer = static_cast<BufferD3D12*>(buffer);
+
+    UP_ASSERT(offset < buffer->size());
+    UP_ASSERT(size <= buffer->size() - offset);
+
+    D3D12_RANGE readRange = {0, 0}; // We do not intend to read from this resource on the CPU.
+    up::byte* data = nullptr;
+    d3dBuffer->buffer()->Map(0, &readRange, reinterpret_cast<void**>(&data));
+    return {static_cast<up::byte*>(data) + offset, static_cast<std::size_t>(size)};
+}
+
+void up::d3d12::CommandListD3D12::unmap(GpuBuffer* buffer, span<up::byte const> data) {
+    if (buffer == nullptr) {
+        return;
+    }
+
+    auto d3dBuffer = static_cast<BufferD3D12*>(buffer);
+    d3dBuffer->buffer()->Unmap(0, nullptr);
+}
+
+void up::d3d12::CommandListD3D12::update(GpuBuffer* buffer, span<up::byte const> data, up::uint64 offset) {
+    if (buffer == nullptr) {
+        return;
+    }
+
+    auto target = map(buffer, data.size(), offset);
+
+    UP_ASSERT(data.size() <= target.size());
+
+    std::memcpy(target.data(), data.data(), data.size());
+    unmap(buffer, target);
+}
+
+void up::d3d12::CommandListD3D12::_flushBindings() {}

--- a/potato/librender/source/d3d12_backend/d3d12_command_list.h
+++ b/potato/librender/source/d3d12_backend/d3d12_command_list.h
@@ -1,0 +1,72 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_command_list.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+
+namespace up::d3d12 {
+    class PipelineStateD3D12;
+
+    class CommandListD3D12 final : public GpuCommandList {
+    public:
+        CommandListD3D12();
+        virtual ~CommandListD3D12();
+
+        CommandListD3D12(CommandListD3D12&&) = delete;
+        CommandListD3D12& operator=(CommandListD3D12&&) = delete;
+
+        static box<CommandListD3D12> createCommandList(
+            ID3D12Device* device,
+            GpuPipelineState* pipelineState,
+            D3D12_COMMAND_LIST_TYPE type);
+
+        bool create(ID3D12Device* device, ID3D12PipelineState* pipelineState, D3D12_COMMAND_LIST_TYPE type);
+
+        void setPipelineState(GpuPipelineState* state) override;
+
+        void bindRenderTarget(uint32 index, GpuResourceView* view) override;
+        void bindDepthStencil(GpuResourceView* view) override;
+        void bindIndexBuffer(GpuBuffer* buffer, GpuIndexFormat indexType, uint32 offset = 0) override;
+        void bindVertexBuffer(uint32 slot, GpuBuffer* buffer, uint64 stride, uint64 offset = 0) override;
+        void bindConstantBuffer(uint32 slot, GpuBuffer* buffer, GpuShaderStage stage) override;
+        void bindConstantValues(uint32 count, float* values, GpuShaderStage stage) override;
+        void bindShaderResource(uint32 slot, GpuResourceView* view, GpuShaderStage stage) override;
+        void bindSampler(uint32 slot, GpuSampler* sampler, GpuShaderStage stage) override;
+        void setClipRect(GpuClipRect rect) override;
+
+        void setPrimitiveTopology(GpuPrimitiveTopology topology) override;
+        void setViewport(GpuViewportDesc const& viewport) override;
+
+        void draw(uint32 vertexCount, uint32 firstVertex = 0) override;
+        void drawIndexed(uint32 indexCount, uint32 firstIndex = 0, uint32 baseIndex = 0) override;
+
+        void clearRenderTarget(GpuResourceView* view, glm::vec4 color) override;
+        void clearDepthStencil(GpuResourceView* view) override;
+
+        void finish() override;
+
+        span<byte> map(GpuBuffer* buffer, uint64 size, uint64 offset = 0) override;
+        void unmap(GpuBuffer* buffer, span<byte const> data) override;
+        void update(GpuBuffer* buffer, span<byte const> data, uint64 offset = 0) override;
+
+        void flush(ID3D12CommandQueue* pQueue);
+
+        ID3DCommandListType* getResource() const { return _commandList.get(); }
+
+    private:
+        void _flushBindings();
+
+        static constexpr uint32 maxRenderTargetBindings = 4;
+
+        bool _bindingsDirty = false;
+        ID3DCommandAllocatorPtr _commandAllocator;
+        ID3DCommandListPtr _commandList;
+
+        // temp stuff to see if I can make this api works
+        PipelineStateD3D12* _pipeline = nullptr;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_desc_heap.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_desc_heap.cpp
@@ -1,0 +1,56 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_desc_heap.h"
+#include "d3d12_device.h"
+#include "d3d12_platform.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/spud/out_ptr.h"
+
+#include <d3d12.h>
+
+up::d3d12::DescriptorHeapD3D12::DescriptorHeapD3D12(ID3D12Device* device, const D3D12_DESCRIPTOR_HEAP_DESC& desc) {
+    create(device, desc);
+}
+
+up::d3d12::DescriptorHeapD3D12::DescriptorHeapD3D12(
+    ID3D12Device* device,
+    uint32 size,
+    D3D12_DESCRIPTOR_HEAP_TYPE type,
+    D3D12_DESCRIPTOR_HEAP_FLAGS flags) {
+    create(device, {.Type = type, .NumDescriptors = size, .Flags = flags, .NodeMask = 0});
+}
+
+up::d3d12::DescriptorHeapD3D12::~DescriptorHeapD3D12() {
+};
+
+auto up::d3d12::DescriptorHeapD3D12::create(ID3D12Device* device, const D3D12_DESCRIPTOR_HEAP_DESC& desc) -> bool {
+    UP_ASSERT(device != nullptr);
+    UP_ASSERT(desc.NumDescriptors != 0);
+    _desc = desc;
+
+    device->CreateDescriptorHeap(&desc, __uuidof(ID3D12DescriptorHeap), out_ptr(_heap));
+    if (!_heap) {
+        return false;
+    }
+
+    _heap->SetName(L"DescriptorHeap");
+    _cpu = _heap->GetCPUDescriptorHandleForHeapStart();
+
+    if (desc.Flags & D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE) {
+        _gpu = _heap->GetGPUDescriptorHandleForHeapStart();
+    }
+    _increment = device->GetDescriptorHandleIncrementSize(desc.Type);
+    return true;
+}
+
+auto up::d3d12::DescriptorHeapD3D12::get_cpu(uint64 index) -> D3D12_CPU_DESCRIPTOR_HANDLE{
+    D3D12_CPU_DESCRIPTOR_HANDLE handle;
+    handle.ptr = static_cast<SIZE_T>(_cpu.ptr + index * static_cast<uint64>(_increment));
+    return handle;
+}
+auto up::d3d12::DescriptorHeapD3D12::get_gpu(uint64 index) -> D3D12_GPU_DESCRIPTOR_HANDLE {
+    D3D12_GPU_DESCRIPTOR_HANDLE handle;
+    handle.ptr = static_cast<SIZE_T>(_gpu.ptr + index * static_cast<uint64>(_increment));
+    return handle;
+}

--- a/potato/librender/source/d3d12_backend/d3d12_desc_heap.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_desc_heap.cpp
@@ -21,8 +21,7 @@ up::d3d12::DescriptorHeapD3D12::DescriptorHeapD3D12(
     create(device, {.Type = type, .NumDescriptors = size, .Flags = flags, .NodeMask = 0});
 }
 
-up::d3d12::DescriptorHeapD3D12::~DescriptorHeapD3D12() {
-};
+up::d3d12::DescriptorHeapD3D12::~DescriptorHeapD3D12(){};
 
 auto up::d3d12::DescriptorHeapD3D12::create(ID3D12Device* device, const D3D12_DESCRIPTOR_HEAP_DESC& desc) -> bool {
     UP_ASSERT(device != nullptr);
@@ -44,7 +43,7 @@ auto up::d3d12::DescriptorHeapD3D12::create(ID3D12Device* device, const D3D12_DE
     return true;
 }
 
-auto up::d3d12::DescriptorHeapD3D12::get_cpu(uint64 index) -> D3D12_CPU_DESCRIPTOR_HANDLE{
+auto up::d3d12::DescriptorHeapD3D12::get_cpu(uint64 index) -> D3D12_CPU_DESCRIPTOR_HANDLE {
     D3D12_CPU_DESCRIPTOR_HANDLE handle;
     handle.ptr = static_cast<SIZE_T>(_cpu.ptr + index * static_cast<uint64>(_increment));
     return handle;

--- a/potato/librender/source/d3d12_backend/d3d12_desc_heap.h
+++ b/potato/librender/source/d3d12_backend/d3d12_desc_heap.h
@@ -1,0 +1,39 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_factory.h"
+#include "potato/runtime/com_ptr.h"
+
+namespace up::d3d12 {
+    // \brief: wrapper for D3D12 descriptor heaps
+    class DescriptorHeapD3D12 {
+    public:
+        DescriptorHeapD3D12(ID3D12Device* device, const D3D12_DESCRIPTOR_HEAP_DESC& desc);
+        DescriptorHeapD3D12(
+            ID3D12Device* device,
+            uint32 size,
+            D3D12_DESCRIPTOR_HEAP_TYPE type,
+            D3D12_DESCRIPTOR_HEAP_FLAGS flags = D3D12_DESCRIPTOR_HEAP_FLAG_NONE);
+
+        virtual ~DescriptorHeapD3D12();
+
+        D3D12_CPU_DESCRIPTOR_HANDLE get_cpu(uint64 index);
+        D3D12_GPU_DESCRIPTOR_HANDLE get_gpu(uint64 index);
+
+        ID3D12DescriptorHeap* heap() const { return _heap.get(); }
+        uint32 increment() const { _increment; }
+
+    protected:
+        bool create(ID3D12Device* device, const D3D12_DESCRIPTOR_HEAP_DESC& desc);
+
+    private:
+        ID3DDescriptorHeapPtr _heap;
+        D3D12_DESCRIPTOR_HEAP_DESC _desc;
+        D3D12_CPU_DESCRIPTOR_HANDLE _cpu;
+        D3D12_GPU_DESCRIPTOR_HANDLE _gpu;
+        uint32 _increment = 0;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_device.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_device.cpp
@@ -1,0 +1,343 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_device.h"
+#include "d3d12_buffer.h"
+#include "d3d12_command_list.h"
+#include "d3d12_context.h"
+#include "d3d12_desc_heap.h"
+#include "d3d12_pipeline_state.h"
+#include "d3d12_platform.h"
+#include "d3d12_renderable.h"
+#include "d3d12_resource_view.h"
+#include "d3d12_root_signature.h"
+#include "d3d12_sampler.h"
+#include "d3d12_swap_chain.h"
+#include "d3d12_texture.h"
+#include "d3d12_utils.h"
+
+#include "potato/render/context.h"
+#include "potato/runtime/assertion.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/out_ptr.h"
+
+#define BYTE unsigned char
+#include "potato/shader/debug_ps_5_1_shader.h"
+#include "potato/shader/debug_vs_5_1_shader.h"
+#undef BYTE
+
+#include <D3D12MemAlloc.h>
+#include <d3d12.h>
+#include <utility>
+
+up::d3d12::DeviceD3D12::DeviceD3D12(IDXGIFactoryPtr factory, IDXGIAdapterPtr adapter)
+    : _factory(std::move(factory))
+    , _adapter(std::move(adapter)) {
+    UP_ASSERT(_factory != nullptr);
+    UP_ASSERT(_adapter != nullptr);
+}
+
+up::d3d12::DeviceD3D12::~DeviceD3D12() {
+    waitForFrame();
+
+    RootSignatureD3D12::destroySignatures();
+
+    _rtvHeap.reset();
+    //    _srvUavHeap.reset();
+    _samplerHeap.reset();
+    _allocator.reset();
+    _device.reset();
+    _adapter.reset();
+    _factory.reset();
+}
+
+auto up::d3d12::DeviceD3D12::createDevice(IDXGIFactoryPtr factory, IDXGIAdapterPtr adapter) -> rc<GpuDevice> {
+    UP_ASSERT(factory != nullptr);
+    UP_ASSERT(adapter != nullptr);
+
+    auto device = new_shared<DeviceD3D12>(std::move(factory), std::move(adapter));
+    device->create();
+    return std::move(device);
+}
+
+bool up::d3d12::DeviceD3D12::create() {
+    D3D12CreateDevice(_adapter.get(), D3D_FEATURE_LEVEL_11_0, __uuidof(ID3D12Device), out_ptr(_device));
+    if (_device == nullptr) {
+        return false;
+    }
+
+    // allocate different descriptor heaps for resource views
+    _rtvHeap = new_box<DescriptorHeapD3D12>(_device.get(), 2, D3D12_DESCRIPTOR_HEAP_TYPE_RTV);
+    _dsvHeap = new_box<DescriptorHeapD3D12>(_device.get(), 2, D3D12_DESCRIPTOR_HEAP_TYPE_DSV);
+    _samplerHeap = new_box<DescriptorHeapD3D12>(
+        _device.get(),
+        1,
+        D3D12_DESCRIPTOR_HEAP_TYPE_SAMPLER,
+        D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
+
+    //#dx12 #todo: for now we will create a single Sampler for the app but in a future we should probably make it more
+    // data driven or move to static sampler definitions in root signatures
+    createDefaultSampler();
+
+    // Describe and create the command queue.
+    D3D12_COMMAND_QUEUE_DESC queueDesc = {};
+    queueDesc.Flags = D3D12_COMMAND_QUEUE_FLAG_NONE;
+    queueDesc.Type = D3D12_COMMAND_LIST_TYPE_DIRECT;
+
+    _device->CreateCommandQueue(&queueDesc, __uuidof(ID3D12CommandQueue), out_ptr(_commandQueue));
+    SetName(_commandQueue.get(), L"commnadQueue");
+
+    createAllocator();
+    createFrameSync();
+
+    RootSignatureD3D12::initializeSignatures(_device.get());
+
+    _mainCmdList = CommandListD3D12::createCommandList(_device.get(), nullptr, D3D12_COMMAND_LIST_TYPE_DIRECT);
+    _uploadCmdList = CommandListD3D12::createCommandList(_device.get(), nullptr, D3D12_COMMAND_LIST_TYPE_COPY);
+
+    _mainContext = new_box<RenderContextD3D12>(this, _mainCmdList.get(), _allocator.get());
+
+    return true;
+}
+
+auto up::d3d12::DeviceD3D12::createRenderable(IRenderable* pInterface) -> box<GpuRenderable> {
+    // #dx12 #todo: use smarter allocation routine
+    return new_box<RenderableD3D12>(pInterface);
+}
+
+auto up::d3d12::DeviceD3D12::createSwapChain(void* nativeWindow) -> rc<GpuSwapChain> {
+    UP_ASSERT(nativeWindow != nullptr);
+
+    return SwapChainD3D12::createSwapChain(
+        _factory.get(),
+        _device.get(),
+        _commandQueue.get(),
+        _rtvHeap.get(),
+        nativeWindow);
+}
+
+auto up::d3d12::DeviceD3D12::createCommandList(GpuPipelineState* pipelineState) -> box<GpuCommandList> {
+    return CommandListD3D12::createCommandList(_device.get(), pipelineState, D3D12_COMMAND_LIST_TYPE_DIRECT);
+}
+
+auto up::d3d12::DeviceD3D12::createRenderTarget(GpuTextureDesc const& desc, GpuSwapChain* swapChain) -> rc<GpuTexture> {
+    UP_ASSERT(swapChain != nullptr);
+
+    /* D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = {_rtvHeap->get_cpu(0)};
+
+      auto rt = static_cast<SwapChainD3D12*>(swapChain)->getBuffer(0);
+      _device->CreateRenderTargetView(rt.get(), nullptr, rtvHandle);*/
+
+    return new_shared<TextureD3D12>();
+}
+auto up::d3d12::DeviceD3D12::createPipelineState(GpuPipelineStateDesc const& desc) -> box<GpuPipelineState> {
+    auto pipeline = PipelineStateD3D12::createGraphicsPipelineState(_device.get(), desc);
+    pipeline->setHeaps(nullptr, _samplerHeap->heap(), _rtvHeap->heap());
+    return pipeline;
+}
+
+auto up::d3d12::DeviceD3D12::createBuffer(GpuBufferType type, up::uint64 size) -> box<GpuBuffer> {
+    auto buffer = new_box<BufferD3D12>();
+
+    buffer->create(*_mainContext.get(), type, size);
+    return buffer;
+}
+
+auto up::d3d12::DeviceD3D12::createTexture2D(GpuTextureDesc const& desc, span<up::byte const> data) -> rc<GpuTexture> {
+    auto bytesPerPixel = toByteSize(desc.format);
+
+    UP_ASSERT(data.empty() || data.size() == desc.width * desc.height * bytesPerPixel);
+    auto texture = new_shared<TextureD3D12>();
+    texture->create(*_mainContext.get(), desc, data);
+
+    return texture;
+}
+
+auto up::d3d12::DeviceD3D12::createSampler() -> box<GpuSampler> {
+    auto sampler = new_box<SamplerD3D12>();
+    sampler->create(_samplerHeap->get_gpu(0));
+    return sampler;
+}
+
+auto up::d3d12::DeviceD3D12::createShaderResourceView(GpuPipelineState* pipeline, GpuTexture* resource)
+    -> box<GpuResourceView> {
+    UP_ASSERT(resource != nullptr);
+
+    auto texture = static_cast<TextureD3D12*>(resource);
+    auto ps = static_cast<PipelineStateD3D12*>(pipeline);
+    auto desc_heap = ps->descHeap();
+
+    // Describe and create a SRV for the texture.
+    D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc = {};
+    srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+    srvDesc.Format = toNative(texture->format());
+    srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+    srvDesc.Texture2D.MipLevels = 1;
+    srvDesc.Texture2D.MostDetailedMip = 0;
+    _device->CreateShaderResourceView(
+        texture->get(),
+        &srvDesc,
+        desc_heap->heap()->GetCPUDescriptorHandleForHeapStart());
+
+    static uint32 __srvcount = 0;
+    auto srv = new_box<ResourceViewD3D12>(GpuViewType::SRV);
+    srv->create(desc_heap, __srvcount++);
+
+    return srv;
+}
+
+auto up::d3d12::DeviceD3D12::createRenderTargetView(GpuTexture* resource) -> box<GpuResourceView> {
+    UP_ASSERT(resource != nullptr);
+
+    // dx12: temp hack to make sure that we offset to the rtvHeap table.  this rvHeap should
+    // live with the resource -- consider wrapping it in a back-buffer object down the line.
+    static uint32 __rtvcount = 0;
+    auto rtv = new_box<ResourceViewD3D12>(GpuViewType::RTV);
+    rtv->create(_rtvHeap.get(), __rtvcount++ % 2);
+
+    return rtv;
+}
+
+auto up::d3d12::DeviceD3D12::createDepthStencilView(GpuTexture* resource) -> box<GpuResourceView> {
+    UP_ASSERT(resource != nullptr);
+
+    auto texture = static_cast<TextureD3D12*>(resource);
+    auto desc_heap = _dsvHeap->heap();
+
+    auto srv = new_box<ResourceViewD3D12>(GpuViewType::DSV);
+    uint32 __dsvcount = 0;
+    srv->create(_dsvHeap.get(), __dsvcount++);
+
+    D3D12_DEPTH_STENCIL_VIEW_DESC depthStencilDesc = {};
+    depthStencilDesc.Format = DXGI_FORMAT_D32_FLOAT;
+    depthStencilDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+    depthStencilDesc.Flags = D3D12_DSV_FLAG_NONE;
+    _device->CreateDepthStencilView(texture->get(), &depthStencilDesc, desc_heap->GetCPUDescriptorHandleForHeapStart());
+
+    return srv;
+}
+
+void up::d3d12::DeviceD3D12::createDefaultSampler() {
+    D3D12_SAMPLER_DESC desc = {};
+    desc.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    desc.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    desc.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    desc.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+    desc.Filter = D3D12_FILTER_MIN_MAG_POINT_MIP_LINEAR;
+    desc.MaxAnisotropy = 1;
+    desc.MaxLOD = 0;
+    desc.MinLOD = 0;
+
+    _device->CreateSampler(&desc, _samplerHeap->get_cpu(0));
+}
+
+void up::d3d12::DeviceD3D12::createAllocator() {
+    static constexpr D3D12MA::ALLOCATOR_FLAGS allocatorFlags = D3D12MA::ALLOCATOR_FLAG_NONE;
+
+    D3D12MA::ALLOCATOR_DESC desc = {};
+    desc.Flags = allocatorFlags;
+    desc.pDevice = _device.get();
+    desc.PreferredBlockSize = 0;
+
+    // if (ENABLE_CPU_ALLOCATION_CALLBACKS) {
+    //    g_AllocationCallbacks.pAllocate = &CustomAllocate;
+    //    g_AllocationCallbacks.pFree = &CustomFree;
+    //    g_AllocationCallbacks.pUserData = CUSTOM_ALLOCATION_USER_DATA;
+    //    desc.pAllocationCallbacks = &g_AllocationCallbacks;
+    //}
+
+    D3D12MA::CreateAllocator(&desc, out_ptr(_allocator));
+
+    switch (_allocator->GetD3D12Options().ResourceHeapTier) {
+        case D3D12_RESOURCE_HEAP_TIER_1:
+            wprintf(L"ResourceHeapTier = D3D12_RESOURCE_HEAP_TIER_1\n");
+            break;
+        case D3D12_RESOURCE_HEAP_TIER_2:
+            wprintf(L"ResourceHeapTier = D3D12_RESOURCE_HEAP_TIER_2\n");
+            break;
+        default:
+            assert(0);
+    }
+}
+
+void up::d3d12::DeviceD3D12::createFrameSync() {
+    _device->CreateFence(0, D3D12_FENCE_FLAG_NONE, __uuidof(ID3D12Fence), out_ptr(_fence));
+    _fenceValue = 1;
+
+    // Create an event handle to use for frame synchronization.
+    _fenceEvent = CreateEvent(nullptr, FALSE, FALSE, nullptr);
+
+    waitForFrame();
+}
+
+void up::d3d12::DeviceD3D12::waitForFrame() {
+    const UINT64 fence = _fenceValue;
+    _commandQueue->Signal(_fence.get(), fence);
+    _fenceValue++;
+
+    // Wait until the previous frame is finished.
+    if (_fence->GetCompletedValue() < fence) {
+        _fence->SetEventOnCompletion(fence, _fenceEvent);
+        WaitForSingleObject(_fenceEvent, INFINITE);
+    }
+}
+
+void up::d3d12::DeviceD3D12::beginFrame(GpuSwapChain* swapChain) {
+    _mainCmdList->start(nullptr);
+
+    swapChain->bind(_mainCmdList.get());
+}
+
+void up::d3d12::DeviceD3D12::endFrame(GpuSwapChain* swapChain) {
+    swapChain->unbind(_mainCmdList.get());
+}
+
+void up::d3d12::DeviceD3D12::beginResourceCreation() {
+    _mainCmdList->start(nullptr);
+}
+
+void up::d3d12::DeviceD3D12::endResourceCreation() {
+    execute(false);
+}
+
+void up::d3d12::DeviceD3D12::clearCommandList() {
+    execute(true);
+    //_mainCmdList->start(nullptr);
+}
+
+void up::d3d12::DeviceD3D12::render(const FrameData& frameData, GpuRenderable* renderable) {
+    UP_ASSERT(renderable);
+    static_cast<RenderableD3D12*>(renderable)->onRender(*_mainContext.get());
+}
+
+void up::d3d12::DeviceD3D12::execute(bool quitting) {
+    UP_ASSERT(_commandQueue != nullptr);
+
+    if (!quitting) {
+        // Close the command list and execute it to begin the initial GPU setup.
+        //_uploadCmdList->finish();
+        _mainCmdList->finish();
+
+        ID3D12CommandList* ppCommandLists[] = {_mainCmdList->getResource()};
+        _commandQueue->ExecuteCommandLists(_countof(ppCommandLists), ppCommandLists);
+    }
+
+    // block until next frame is done on GPU before we start new frame
+    waitForFrame();
+}
+
+auto up::d3d12::DeviceD3D12::getDebugShader(GpuShaderStage stage) -> view<unsigned char> {
+    switch (stage) {
+        case GpuShaderStage::Vertex:
+            return g_vertex_main;
+        case GpuShaderStage::Pixel:
+            return g_pixel_main;
+        default:
+            return {};
+    }
+}
+
+void up::d3d12::DeviceD3D12::debugDraw(delegate_ref<void(GpuCommandList& cmdList)> callback) {
+    callback(*_mainCmdList.get());
+}
+
+void up::d3d12::DeviceD3D12::registerAssetBackends(AssetLoader& assetLoader) { }

--- a/potato/librender/source/d3d12_backend/d3d12_device.h
+++ b/potato/librender/source/d3d12_backend/d3d12_device.h
@@ -1,0 +1,84 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_device.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/unique_resource.h"
+
+namespace up::d3d12 {
+    class CommandListD3D12;
+    class DescriptorHeapD3D12;
+    class RenderContextD3D12;
+
+    class DeviceD3D12 final : public GpuDevice {
+    public:
+        DeviceD3D12(IDXGIFactoryPtr factory, IDXGIAdapterPtr adapter);
+        virtual ~DeviceD3D12();
+
+        DeviceD3D12(DeviceD3D12&&) = delete;
+        DeviceD3D12& operator=(DeviceD3D12&&) = delete;
+
+        static rc<GpuDevice> createDevice(IDXGIFactoryPtr factory, IDXGIAdapterPtr adapter);
+
+        rc<GpuSwapChain> createSwapChain(void* nativeWindow) override;
+        box<GpuCommandList> createCommandList(GpuPipelineState* pipelineState = nullptr) override;
+        box<GpuPipelineState> createPipelineState(GpuPipelineStateDesc const& desc) override;
+        box<GpuBuffer> createBuffer(GpuBufferType type, uint64 size) override;
+        rc<GpuTexture> createTexture2D(GpuTextureDesc const& desc, span<byte const> data) override;
+        box<GpuSampler> createSampler() override;
+
+        box<GpuResourceView> createShaderResourceView(GpuPipelineState* pipeline, GpuTexture* resource) override;
+        box<GpuResourceView> createRenderTargetView(GpuTexture* resource) override;
+        box<GpuResourceView> createDepthStencilView(GpuTexture* resource) override;
+
+        bool create();
+        void execute(bool quitting);
+
+        void beginFrame(GpuSwapChain* swapChain) override;
+        void endFrame(GpuSwapChain* swapChain) override;
+
+        void beginResourceCreation() override;
+        void endResourceCreation() override;
+
+        void clearCommandList() override;
+
+        void registerAssetBackends(AssetLoader& assetLoader) override;
+
+        ID3D12Device* getDevice() const { return _device.get(); }
+
+    protected:
+        void createDefaultSampler();
+        void createAllocator();
+        void createFrameSync();
+        void waitForFrame();
+
+    private:
+        IDXGIFactoryPtr _factory;
+        IDXGIAdapterPtr _adapter;
+        ID3DDevicePtr _device;
+
+        box<DescriptorHeapD3D12> _rtvHeap;
+        box<DescriptorHeapD3D12> _dsvHeap;
+        box<DescriptorHeapD3D12> _samplerHeap;
+
+        ID3DCommandQueuePtr _commandQueue;
+
+        // main command list -- for now we use single command list but that will most likely change
+        // in the future
+        box<CommandListD3D12> _mainCmdList;
+        box<CommandListD3D12> _uploadCmdList;
+        box<RenderContextD3D12> _mainContext;
+
+        // Synchronization objects.
+        UINT _frameIndex;
+        HANDLE _fenceEvent;
+        com_ptr<ID3D12Fence> _fence;
+        UINT64 _fenceValue;
+
+        // allocator
+        com_ptr<D3D12MA::Allocator> _allocator;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_factory.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_factory.cpp
@@ -1,6 +1,5 @@
 // Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
-
 #include "d3d12_factory.h"
 #include "d3d12_device.h"
 #include "d3d12_platform.h"
@@ -18,7 +17,6 @@ up::d3d12::FactoryD3D12::~FactoryD3D12() = default;
 
 #if defined(UP_GPU_ENABLE_D3D12)
 auto up::CreateFactoryD3D12() -> box<GpuDeviceFactory> {
-
     UINT dxgiFactoryFlags = 0;
 
 #    if defined(_DEBUG)

--- a/potato/librender/source/d3d12_backend/d3d12_factory.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_factory.cpp
@@ -1,0 +1,69 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+
+#include "d3d12_factory.h"
+#include "d3d12_device.h"
+#include "d3d12_platform.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/spud/out_ptr.h"
+
+#include <d3d12.h>
+
+up::d3d12::FactoryD3D12::FactoryD3D12(IDXGIFactoryPtr dxgiFactory) : _dxgiFactory(std::move(dxgiFactory)) {
+    UP_ASSERT(_dxgiFactory != nullptr);
+}
+
+up::d3d12::FactoryD3D12::~FactoryD3D12() = default;
+
+#if defined(UP_GPU_ENABLE_D3D12)
+auto up::CreateFactoryD3D12() -> box<GpuDeviceFactory> {
+
+    UINT dxgiFactoryFlags = 0;
+
+#    if defined(_DEBUG)
+    // Enable the debug layer (requires the Graphics Tools "optional feature").
+    // NOTE: Enabling the debug layer after device creation will invalidate the active device.
+    {
+        com_ptr<ID3D12Debug> debugController;
+        if (SUCCEEDED(D3D12GetDebugInterface(__uuidof(ID3D12Debug), out_ptr(debugController)))) {
+            debugController->EnableDebugLayer();
+
+            // Enable additional debug layers.
+            dxgiFactoryFlags |= DXGI_CREATE_FACTORY_DEBUG;
+        }
+    }
+#    endif
+
+    IDXGIFactoryPtr factory;
+    CreateDXGIFactory2(dxgiFactoryFlags, __uuidof(IDXGIFactoryType), out_ptr(factory));
+    return new_box<d3d12::FactoryD3D12>(std::move(factory));
+}
+#endif
+
+bool up::d3d12::FactoryD3D12::isEnabled() const {
+    return true;
+}
+
+void up::d3d12::FactoryD3D12::enumerateDevices(delegate<void(GpuDeviceInfo const&)> callback) {
+    com_ptr<IDXGIAdapterType> adapter;
+
+    int index = 0;
+    while (_dxgiFactory->EnumAdapters1(index, out_ptr(adapter)) == S_OK) {
+        GpuDeviceInfo info = {index};
+        callback(info);
+    }
+}
+
+auto up::d3d12::FactoryD3D12::createDevice(int index) -> rc<GpuDevice> {
+    com_ptr<IDXGIAdapterType> adapter;
+
+    UINT targetIndex = 0;
+    while (_dxgiFactory->EnumAdapters1(index, out_ptr(adapter)) == S_OK) {
+        if (targetIndex == index) {
+            return DeviceD3D12::createDevice(_dxgiFactory, std::move(adapter));
+        }
+    }
+
+    return nullptr;
+}

--- a/potato/librender/source/d3d12_backend/d3d12_factory.h
+++ b/potato/librender/source/d3d12_backend/d3d12_factory.h
@@ -1,0 +1,26 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_factory.h"
+#include "potato/runtime/com_ptr.h"
+
+namespace up::d3d12 {
+    class FactoryD3D12 final : public GpuDeviceFactory {
+    public:
+        FactoryD3D12(IDXGIFactoryPtr dxgiFactory);
+        virtual ~FactoryD3D12();
+
+        FactoryD3D12(FactoryD3D12&&) = delete;
+        FactoryD3D12& operator=(FactoryD3D12&&) = delete;
+
+        bool isEnabled() const override;
+        void enumerateDevices(delegate<void(GpuDeviceInfo const&)> callback) override;
+        rc<GpuDevice> createDevice(int index) override;
+
+    private:
+        IDXGIFactoryPtr _dxgiFactory;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_pipeline_state.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_pipeline_state.cpp
@@ -1,0 +1,176 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_pipeline_state.h"
+#include "d3d12_command_list.h"
+#include "d3d12_desc_heap.h"
+#include "d3d12_root_signature.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/spud/out_ptr.h"
+
+static D3D12_BLEND_DESC defaultBlendState() {
+    D3D12_BLEND_DESC blend = {};
+    blend.AlphaToCoverageEnable = FALSE;
+    blend.IndependentBlendEnable = FALSE;
+
+    D3D12_RENDER_TARGET_BLEND_DESC rtBlendOps = {};
+
+    rtBlendOps.BlendEnable = TRUE;
+    rtBlendOps.LogicOpEnable = FALSE;
+    rtBlendOps.SrcBlend = D3D12_BLEND_SRC_ALPHA;
+    rtBlendOps.DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
+    rtBlendOps.BlendOp = D3D12_BLEND_OP_ADD;
+    rtBlendOps.SrcBlendAlpha = D3D12_BLEND_SRC_ALPHA;
+    rtBlendOps.DestBlendAlpha = D3D12_BLEND_ZERO;
+    rtBlendOps.BlendOpAlpha = D3D12_BLEND_OP_ADD;
+    rtBlendOps.LogicOp = D3D12_LOGIC_OP_CLEAR;
+    rtBlendOps.RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
+
+    for (up::uint32 i = 0; i < D3D12_SIMULTANEOUS_RENDER_TARGET_COUNT; ++i) {
+        blend.RenderTarget[i] = rtBlendOps;
+    }
+
+    return blend;
+}
+
+static D3D12_RASTERIZER_DESC defaultRestirizerState() {
+    D3D12_RASTERIZER_DESC rs = {};
+
+    rs.FillMode = D3D12_FILL_MODE_SOLID;
+    rs.CullMode = D3D12_CULL_MODE_NONE;
+
+    rs.FrontCounterClockwise = FALSE;
+    rs.DepthBias = D3D12_DEFAULT_DEPTH_BIAS;
+    rs.DepthBiasClamp = D3D12_DEFAULT_DEPTH_BIAS_CLAMP;
+    rs.SlopeScaledDepthBias = D3D12_DEFAULT_SLOPE_SCALED_DEPTH_BIAS;
+    rs.DepthClipEnable = TRUE;
+    rs.MultisampleEnable = FALSE;
+    rs.AntialiasedLineEnable = FALSE;
+    rs.ForcedSampleCount = 0;
+    rs.ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
+
+    return rs;
+}
+
+static D3D12_DEPTH_STENCIL_DESC defeaultDepthStencilState() {
+    D3D12_DEPTH_STENCIL_DESC desc = {};
+    desc.DepthEnable = false;
+    desc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
+    desc.DepthFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+    desc.StencilEnable = false;
+    desc.FrontFace.StencilFailOp = desc.FrontFace.StencilDepthFailOp = desc.FrontFace.StencilPassOp =
+        D3D12_STENCIL_OP_KEEP;
+    desc.FrontFace.StencilFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+    desc.BackFace = desc.FrontFace;
+
+    return desc;
+}
+
+
+up::d3d12::PipelineStateD3D12::PipelineStateD3D12()  {
+}
+
+up::d3d12::PipelineStateD3D12::~PipelineStateD3D12() {
+};
+
+auto up::d3d12::PipelineStateD3D12::createGraphicsPipelineState(ID3D12Device* device, GpuPipelineStateDesc const& desc)
+    -> box<PipelineStateD3D12> {
+    UP_ASSERT(device != nullptr);
+    auto pso = new_box<PipelineStateD3D12>();
+    pso->create(device, desc); 
+    return pso;
+}
+
+bool up::d3d12::PipelineStateD3D12::create(ID3D12Device* device, GpuPipelineStateDesc const& desc) {
+    std::vector<D3D12_INPUT_ELEMENT_DESC> elements;
+    uint32 offset = 0;
+    for (auto i : desc.inputLayout) {
+        D3D12_INPUT_ELEMENT_DESC desc = {
+            toNative(i.semantic).c_str(),
+            0,
+            toNative(i.format),
+            0,
+            offset,
+            D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA,
+            0};
+
+        offset += toByteSize(i.format);
+        elements.push_back(desc);
+    }
+
+    _signature = RootSignatureD3D12::getRootSignature(desc.signatureType);
+
+    // Describe and create the graphics pipeline state object (PSO).
+    D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc = {};
+    psoDesc.NodeMask = 1;
+    psoDesc.InputLayout = {elements.data(), static_cast<UINT>(elements.size())};
+    psoDesc.pRootSignature = _signature->signature();
+    psoDesc.VS = {desc.vertShader.data(), desc.vertShader.size()};
+    psoDesc.PS = {desc.pixelShader.data(), desc.pixelShader.size()};
+    psoDesc.RasterizerState = defaultRestirizerState();
+    psoDesc.BlendState = defaultBlendState();
+    psoDesc.DepthStencilState = defeaultDepthStencilState();
+    psoDesc.SampleMask = UINT_MAX;
+    psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+    psoDesc.NumRenderTargets = 1;
+    psoDesc.DSVFormat = DXGI_FORMAT_D32_FLOAT;
+    psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM;
+    psoDesc.SampleDesc.Count = 1;
+    psoDesc.Flags = D3D12_PIPELINE_STATE_FLAG_NONE;
+
+    device->CreateGraphicsPipelineState(&psoDesc, __uuidof(ID3D12PipelineState), out_ptr(_state));
+
+    _srvHeap = new_box<DescriptorHeapD3D12>(
+        device,
+        1,
+        D3D12_DESCRIPTOR_HEAP_TYPE_CBV_SRV_UAV,
+        D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE);
+
+    return true;
+}
+    
+
+void up::d3d12::PipelineStateD3D12::bindPipeline(ID3D12GraphicsCommandList* cmd) {
+    UP_ASSERT(cmd!=nullptr);
+
+    cmd->SetGraphicsRootSignature(_signature->signature());
+    cmd->SetPipelineState(_state.get());
+
+    // Setup blend factor
+    const float blend_factor[4] = {0.f, 0.f, 0.f, 0.f};
+    cmd->OMSetBlendFactor(blend_factor);
+    
+    ID3D12DescriptorHeap* ppHeaps[] = {_srvHeap->heap(), _samplerHeap};
+    cmd->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
+}
+
+void up::d3d12::PipelineStateD3D12::bindTexture(
+    ID3D12GraphicsCommandList* cmd,
+    uint32 offset,
+    D3D12_GPU_DESCRIPTOR_HANDLE srv,
+    D3D12_GPU_DESCRIPTOR_HANDLE sampler) {
+    UP_ASSERT(cmd != nullptr);
+
+    uint32 srvOffset = _signature->getRootOffset(RootParamType::Texture); 
+    uint32 samplerOffset = _signature->getRootOffset(RootParamType::Sampler);
+    cmd->SetGraphicsRootDescriptorTable(srvOffset, srv);
+    cmd->SetGraphicsRootDescriptorTable(samplerOffset, sampler);
+}
+
+void up::d3d12::PipelineStateD3D12::bindConstBuffer(
+    ID3D12GraphicsCommandList* cmd,
+    uint32 offset,
+    D3D12_GPU_VIRTUAL_ADDRESS cbv) {
+    UP_ASSERT(cmd != nullptr);
+
+    uint32 rootOffset = _signature->getRootOffset(RootParamType::ConstBuffer);
+    UP_ASSERT(rootOffset != 0xffffff);
+    cmd->SetGraphicsRootConstantBufferView(rootOffset + offset, cbv);
+}
+
+void up::d3d12::PipelineStateD3D12::bindConstValues(ID3D12GraphicsCommandList* cmd, uint32 size, float* values) {
+    UP_ASSERT(cmd != nullptr);
+    uint32 rootOffset = _signature->getRootOffset(RootParamType::ConstValues);
+    UP_ASSERT(rootOffset != 0xffffff);
+    cmd->SetGraphicsRoot32BitConstants(rootOffset, size, values, 0);
+}

--- a/potato/librender/source/d3d12_backend/d3d12_pipeline_state.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_pipeline_state.cpp
@@ -66,18 +66,15 @@ static D3D12_DEPTH_STENCIL_DESC defeaultDepthStencilState() {
     return desc;
 }
 
+up::d3d12::PipelineStateD3D12::PipelineStateD3D12() { }
 
-up::d3d12::PipelineStateD3D12::PipelineStateD3D12()  {
-}
-
-up::d3d12::PipelineStateD3D12::~PipelineStateD3D12() {
-};
+up::d3d12::PipelineStateD3D12::~PipelineStateD3D12(){};
 
 auto up::d3d12::PipelineStateD3D12::createGraphicsPipelineState(ID3D12Device* device, GpuPipelineStateDesc const& desc)
     -> box<PipelineStateD3D12> {
     UP_ASSERT(device != nullptr);
     auto pso = new_box<PipelineStateD3D12>();
-    pso->create(device, desc); 
+    pso->create(device, desc);
     return pso;
 }
 
@@ -128,10 +125,9 @@ bool up::d3d12::PipelineStateD3D12::create(ID3D12Device* device, GpuPipelineStat
 
     return true;
 }
-    
 
 void up::d3d12::PipelineStateD3D12::bindPipeline(ID3D12GraphicsCommandList* cmd) {
-    UP_ASSERT(cmd!=nullptr);
+    UP_ASSERT(cmd != nullptr);
 
     cmd->SetGraphicsRootSignature(_signature->signature());
     cmd->SetPipelineState(_state.get());
@@ -139,7 +135,7 @@ void up::d3d12::PipelineStateD3D12::bindPipeline(ID3D12GraphicsCommandList* cmd)
     // Setup blend factor
     const float blend_factor[4] = {0.f, 0.f, 0.f, 0.f};
     cmd->OMSetBlendFactor(blend_factor);
-    
+
     ID3D12DescriptorHeap* ppHeaps[] = {_srvHeap->heap(), _samplerHeap};
     cmd->SetDescriptorHeaps(_countof(ppHeaps), ppHeaps);
 }
@@ -151,7 +147,7 @@ void up::d3d12::PipelineStateD3D12::bindTexture(
     D3D12_GPU_DESCRIPTOR_HANDLE sampler) {
     UP_ASSERT(cmd != nullptr);
 
-    uint32 srvOffset = _signature->getRootOffset(RootParamType::Texture); 
+    uint32 srvOffset = _signature->getRootOffset(RootParamType::Texture);
     uint32 samplerOffset = _signature->getRootOffset(RootParamType::Sampler);
     cmd->SetGraphicsRootDescriptorTable(srvOffset, srv);
     cmd->SetGraphicsRootDescriptorTable(samplerOffset, sampler);

--- a/potato/librender/source/d3d12_backend/d3d12_pipeline_state.h
+++ b/potato/librender/source/d3d12_backend/d3d12_pipeline_state.h
@@ -1,0 +1,60 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_pipeline_state.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+#include "potato/spud/rc.h"
+
+namespace up::d3d12 {
+
+    class CommandListD3D12;
+    class DescriptorHeapD3D12;
+    class RootSignatureD3D12;
+
+    class PipelineStateD3D12 : public GpuPipelineState {
+    public:
+        explicit PipelineStateD3D12();
+        virtual ~PipelineStateD3D12();
+
+        static box<PipelineStateD3D12> createGraphicsPipelineState(
+            ID3D12Device* device,
+            GpuPipelineStateDesc const& desc);
+
+        bool create(ID3D12Device* device, GpuPipelineStateDesc const& desc);
+
+        void setHeaps(ID3D12DescriptorHeap* dsvHeap, ID3D12DescriptorHeap* samplerHeap, ID3D12DescriptorHeap* rtHeap) {
+            _samplerHeap = samplerHeap;
+            _rtvHeap = rtHeap;
+            _dsvHeap = dsvHeap;
+        }
+
+        void bindPipeline(ID3D12GraphicsCommandList* cmd);
+        void bindTexture(
+            ID3D12GraphicsCommandList* cmd,
+            uint32 offset,
+            D3D12_GPU_DESCRIPTOR_HANDLE srv,
+            D3D12_GPU_DESCRIPTOR_HANDLE sampler);
+        void bindConstBuffer(ID3D12GraphicsCommandList* cmd, uint32 offset, D3D12_GPU_VIRTUAL_ADDRESS cbv);
+        void bindConstValues(ID3D12GraphicsCommandList* cmd, uint32 size, float* values);
+
+        ID3D12PipelineState* state() const { return _state.get(); }
+
+        DescriptorHeapD3D12* descHeap() const { return _srvHeap.get(); }
+
+    private:
+        ID3DPipelineStatePtr _state;
+        rc<RootSignatureD3D12> _signature;
+
+        // pipeline owned descriptor heap for shader resources
+        box<DescriptorHeapD3D12> _srvHeap;
+
+        // non-owned (external) descriptor heaps
+        ID3D12DescriptorHeap* _samplerHeap;
+        ID3D12DescriptorHeap* _rtvHeap;
+        ID3D12DescriptorHeap* _dsvHeap;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_platform.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_platform.cpp
@@ -1,0 +1,101 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_platform.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/spud/utility.h"
+
+auto up::d3d12::toNative(GpuShaderSemantic semantic) noexcept -> zstring_view {
+    switch (semantic) {
+        case GpuShaderSemantic::Position:
+            return "POSITION";
+        case GpuShaderSemantic::Color:
+            return "COLOR";
+        case GpuShaderSemantic::Normal:
+            return "NORMAL";
+        case GpuShaderSemantic::Tangent:
+            return "TANGENT";
+        case GpuShaderSemantic::TexCoord:
+            return "TEXCOORD";
+        default:
+            UP_UNREACHABLE("Unknown Semantic");
+            return "UNKNOWN";
+    }
+}
+
+auto up::d3d12::toByteSize(GpuShaderSemantic sementic) noexcept -> uint32 {
+    switch (sementic) {
+        case GpuShaderSemantic::Position:
+        case GpuShaderSemantic::Normal:
+        case GpuShaderSemantic::Tangent:
+            return 12;
+        case GpuShaderSemantic::Color:
+            return 16;
+        case GpuShaderSemantic::TexCoord:
+            return 8;
+        default:
+            UP_UNREACHABLE("Unknown Semantic");
+            return 0;
+    }
+}
+
+auto up::d3d12::toNative(GpuFormat format) noexcept -> DXGI_FORMAT {
+    const DXGI_FORMAT toNativeTable[] = {
+        DXGI_FORMAT_UNKNOWN, // Unknown
+        DXGI_FORMAT_R32G32B32A32_FLOAT, // R32G32B32A32Float
+        DXGI_FORMAT_R32G32B32_FLOAT, // R32G32B32Float
+        DXGI_FORMAT_R32G32_FLOAT, // R32G32Float
+        DXGI_FORMAT_R8G8B8A8_UNORM, // R8G8B8A8UnsignedNormalized
+        DXGI_FORMAT_D32_FLOAT, // D32Float
+
+        DXGI_FORMAT_FORCE_UINT, // Max
+    };
+
+    return toNativeTable[to_underlying(format)];
+}
+
+auto up::d3d12::fromNative(DXGI_FORMAT format) noexcept -> GpuFormat {
+    switch (format) {
+        case DXGI_FORMAT_R32G32B32A32_FLOAT:
+            return GpuFormat::R32G32B32A32Float;
+        case DXGI_FORMAT_R32G32B32_FLOAT:
+            return GpuFormat::R32G32B32Float;
+        case DXGI_FORMAT_R32G32_FLOAT:
+            return GpuFormat::R32G32Float;
+        case DXGI_FORMAT_R8G8B8A8_UNORM:
+            return GpuFormat::R8G8B8A8UnsignedNormalized;
+        case DXGI_FORMAT_D32_FLOAT:
+            return GpuFormat::D32Float;
+        default:
+            return GpuFormat::Unknown;
+    }
+}
+
+auto up::d3d12::toByteSize(GpuFormat format) noexcept -> up::uint32 {
+    switch (format) {
+        case GpuFormat::R32G32B32A32Float:
+            return 16;
+        case GpuFormat::R32G32B32Float:
+            return 12;
+        case GpuFormat::R32G32Float:
+            return 8;
+        case GpuFormat::R8G8B8A8UnsignedNormalized:
+        case GpuFormat::D32Float:
+            return 4;
+        default:
+            UP_UNREACHABLE("Unknown Format");
+            return 0;
+    }
+}
+
+auto up::d3d12::toNative(GpuIndexFormat type) noexcept -> DXGI_FORMAT {
+    switch (type) {
+        case GpuIndexFormat::Unsigned16:
+            return DXGI_FORMAT_R16_UINT;
+        case GpuIndexFormat::Unsigned32:
+            return DXGI_FORMAT_R32_UINT;
+        default:
+            UP_UNREACHABLE("Unknown GpuIndexFormat");
+            return DXGI_FORMAT_UNKNOWN;
+    }
+}

--- a/potato/librender/source/d3d12_backend/d3d12_platform.h
+++ b/potato/librender/source/d3d12_backend/d3d12_platform.h
@@ -1,0 +1,44 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "potato/render/gpu_common.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/platform_windows.h"
+#include "potato/spud/zstring_view.h"
+
+#include <D3D12MemAlloc.h>
+#include <d3d12.h>
+#include <dxgi1_6.h>
+
+// helper global defines
+using IDXGIFactoryType = IDXGIFactory4;
+using IDXGIFactoryPtr = up::com_ptr<IDXGIFactoryType>;
+using IDXGIAdapterType = IDXGIAdapter1;
+using IDXGIAdapterPtr = up::com_ptr<IDXGIAdapterType>;
+using IDXGISwapChainType = IDXGISwapChain3;
+using IDXGISwapChainPtr = up::com_ptr<IDXGISwapChainType>;
+
+using ID3DDeviceType = ID3D12Device;
+using ID3DDevicePtr = up::com_ptr<ID3D12Device>;
+using ID3DResourceType = ID3D12Resource;
+using ID3DResourcePtr = up::com_ptr<ID3D12Resource>;
+
+using ID3DCommandAllocatorPtr = up::com_ptr<ID3D12CommandAllocator>;
+
+using ID3DCommandListType = ID3D12GraphicsCommandList;
+using ID3DCommandListPtr = up::com_ptr<ID3DCommandListType>;
+using ID3DCommandQueuePtr = up::com_ptr<ID3D12CommandQueue>;
+using ID3DDescriptorHeapPtr = up::com_ptr<ID3D12DescriptorHeap>;
+using ID3DPipelineStatePtr = up::com_ptr<ID3D12PipelineState>;
+using ID3DRootSignaturePtr = up::com_ptr<ID3D12RootSignature>;
+using ID3DFencePtr = up::com_ptr<ID3D12Fence>;
+
+namespace up::d3d12 {
+    extern zstring_view toNative(GpuShaderSemantic semantic) noexcept;
+    extern uint32 toByteSize(GpuShaderSemantic sementic) noexcept;
+    extern DXGI_FORMAT toNative(GpuFormat format) noexcept;
+    extern GpuFormat fromNative(DXGI_FORMAT format) noexcept;
+    extern uint32 toByteSize(GpuFormat format) noexcept;
+    extern DXGI_FORMAT toNative(GpuIndexFormat type) noexcept;
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_resource_view.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_resource_view.cpp
@@ -3,18 +3,16 @@
 #include "d3d12_resource_view.h"
 #include "d3d12_desc_heap.h"
 
-up::d3d12::ResourceViewD3D12::ResourceViewD3D12(GpuViewType type)
-    : _type(type)
-{}
+up::d3d12::ResourceViewD3D12::ResourceViewD3D12(GpuViewType type) : _type(type) { }
 
 up::d3d12::ResourceViewD3D12::~ResourceViewD3D12() = default;
 
 void up::d3d12::ResourceViewD3D12::create(DescriptorHeapD3D12* heap, uint32 index) {
     _heap = heap;
-    _index = index; 
+    _index = index;
 }
 
-auto up::d3d12::ResourceViewD3D12::getCpuDesc() const -> D3D12_CPU_DESCRIPTOR_HANDLE{
+auto up::d3d12::ResourceViewD3D12::getCpuDesc() const -> D3D12_CPU_DESCRIPTOR_HANDLE {
     UP_ASSERT(_heap);
     return _heap->get_cpu(_index);
 }

--- a/potato/librender/source/d3d12_backend/d3d12_resource_view.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_resource_view.cpp
@@ -1,0 +1,25 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_resource_view.h"
+#include "d3d12_desc_heap.h"
+
+up::d3d12::ResourceViewD3D12::ResourceViewD3D12(GpuViewType type)
+    : _type(type)
+{}
+
+up::d3d12::ResourceViewD3D12::~ResourceViewD3D12() = default;
+
+void up::d3d12::ResourceViewD3D12::create(DescriptorHeapD3D12* heap, uint32 index) {
+    _heap = heap;
+    _index = index; 
+}
+
+auto up::d3d12::ResourceViewD3D12::getCpuDesc() const -> D3D12_CPU_DESCRIPTOR_HANDLE{
+    UP_ASSERT(_heap);
+    return _heap->get_cpu(_index);
+}
+
+auto up::d3d12::ResourceViewD3D12::getGpuDesc() const -> D3D12_GPU_DESCRIPTOR_HANDLE {
+    UP_ASSERT(_heap);
+    return _heap->get_gpu(_index);
+}

--- a/potato/librender/source/d3d12_backend/d3d12_resource_view.h
+++ b/potato/librender/source/d3d12_backend/d3d12_resource_view.h
@@ -1,0 +1,35 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_resource_view.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+
+namespace up::d3d12 {
+    class DescriptorHeapD3D12;
+    class ResourceViewD3D12 final : public GpuResourceView {
+    public:
+        explicit ResourceViewD3D12(GpuViewType type);
+        virtual ~ResourceViewD3D12();
+
+        ResourceViewD3D12(ResourceViewD3D12&&) = delete;
+        ResourceViewD3D12& operator=(ResourceViewD3D12&&) = delete;
+
+        void create(DescriptorHeapD3D12* heap, uint32 index);
+
+        GpuViewType type() const override { return _type; }
+
+        DescriptorHeapD3D12* heap() { return _heap; }
+
+        D3D12_CPU_DESCRIPTOR_HANDLE getCpuDesc() const;
+        D3D12_GPU_DESCRIPTOR_HANDLE getGpuDesc() const;
+
+    private:
+        GpuViewType _type;
+        DescriptorHeapD3D12* _heap = nullptr;
+        uint32 _index = 0;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_root_signature.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_root_signature.cpp
@@ -1,0 +1,293 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_root_signature.h"
+#include "d3d12_command_list.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/spud/out_ptr.h"
+
+up::d3d12::RootSignatureD3D12::RootSignatureD3D12() {}
+
+up::d3d12::RootSignatureD3D12::~RootSignatureD3D12(){};
+
+static inline void Init_1_1(
+    _Out_ D3D12_VERSIONED_ROOT_SIGNATURE_DESC& desc,
+    UINT numParameters,
+    _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER1* _pParameters,
+    UINT numStaticSamplers = 0,
+    _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
+    D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept {
+    desc.Version = D3D_ROOT_SIGNATURE_VERSION_1_1;
+    desc.Desc_1_1.NumParameters = numParameters;
+    desc.Desc_1_1.pParameters = _pParameters;
+    desc.Desc_1_1.NumStaticSamplers = numStaticSamplers;
+    desc.Desc_1_1.pStaticSamplers = _pStaticSamplers;
+    desc.Desc_1_1.Flags = flags;
+}
+
+static inline void InitRootSignatureDesc(
+    _Out_ D3D12_ROOT_SIGNATURE_DESC& desc,
+    UINT numParameters,
+    _In_reads_opt_(numParameters) const D3D12_ROOT_PARAMETER* _pParameters,
+    UINT numStaticSamplers = 0,
+    _In_reads_opt_(numStaticSamplers) const D3D12_STATIC_SAMPLER_DESC* _pStaticSamplers = nullptr,
+    D3D12_ROOT_SIGNATURE_FLAGS flags = D3D12_ROOT_SIGNATURE_FLAG_NONE) noexcept {
+    desc.NumParameters = numParameters;
+    desc.pParameters = _pParameters;
+    desc.NumStaticSamplers = numStaticSamplers;
+    desc.pStaticSamplers = _pStaticSamplers;
+    desc.Flags = flags;
+}
+
+static up::vector<up::rc<up::d3d12::RootSignatureD3D12>> s_RootSignatures;
+
+auto up::d3d12::RootSignatureD3D12::initializeSignatures(ID3D12Device* device) -> bool {
+    s_RootSignatures.resize(RootSignatureType::eRST_Max);
+
+    SignatureDesc imguiDesc;
+    imguiDesc.resize(4);
+    imguiDesc.initSRVs(0, 1, D3D12_SHADER_VISIBILITY_PIXEL);
+    imguiDesc.initSamplers(1, 1, D3D12_SHADER_VISIBILITY_PIXEL);
+    imguiDesc.initConstBuffer(2, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+    imguiDesc.initConstBuffer(3, 1, D3D12_SHADER_VISIBILITY_VERTEX);
+    s_RootSignatures[RootSignatureType::eRST_ImGui] = RootSignatureD3D12::createRootSignature(device, imguiDesc);
+
+    SignatureDesc modelDesc;
+    modelDesc.resize(5);
+    // imguiDesc._params[0].initAsConstants(16, 0, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+    modelDesc.initSRVs(0, 3, D3D12_SHADER_VISIBILITY_PIXEL);
+    modelDesc.initSamplers(1, 3, D3D12_SHADER_VISIBILITY_PIXEL);
+    modelDesc.initConstBuffer(2, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+    modelDesc.initConstBuffer(3, 1, D3D12_SHADER_VISIBILITY_VERTEX);
+    modelDesc.initConstBuffer(4, 2, D3D12_SHADER_VISIBILITY_VERTEX);
+    s_RootSignatures[RootSignatureType::eRST_FullModel] = RootSignatureD3D12::createRootSignature(device, modelDesc);
+
+    SignatureDesc debugDesc;
+    debugDesc.resize(2);
+    debugDesc.initConstBuffer(0, 0, D3D12_SHADER_VISIBILITY_VERTEX);
+    debugDesc.initConstBuffer(1, 1, D3D12_SHADER_VISIBILITY_ALL);
+    s_RootSignatures[RootSignatureType::eRST_DebugDraw] = RootSignatureD3D12::createRootSignature(device, debugDesc);
+
+    return true;
+};
+
+auto up::d3d12::RootSignatureD3D12::destroySignatures() -> bool {
+    s_RootSignatures.clear();
+    return true;
+};
+
+auto up::d3d12::RootSignatureD3D12::getRootSignature(RootSignatureType type) -> rc<up::d3d12::RootSignatureD3D12> {
+    return s_RootSignatures[type];
+};
+
+//------------------------------------------------------------------------------------------------
+// D3D12 exports a new method for serializing root signatures in the Windows 10 Anniversary Update.
+// To help enable root signature 1.1 features when they are available and not require maintaining
+// two code paths for building root signatures, this helper method reconstructs a 1.0 signature when
+// 1.1 is not supported.
+inline HRESULT D3DX12SerializeVersionedRootSignature(
+    _In_ const D3D12_VERSIONED_ROOT_SIGNATURE_DESC* pRootSignatureDesc,
+    D3D_ROOT_SIGNATURE_VERSION MaxVersion,
+    _Outptr_ ID3DBlob** ppBlob,
+    _Always_(_Outptr_opt_result_maybenull_) ID3DBlob** ppErrorBlob) noexcept {
+    if (ppErrorBlob != nullptr) {
+        *ppErrorBlob = nullptr;
+    }
+
+    switch (MaxVersion) {
+        case D3D_ROOT_SIGNATURE_VERSION_1_0:
+            switch (pRootSignatureDesc->Version) {
+                case D3D_ROOT_SIGNATURE_VERSION_1_0:
+                    return D3D12SerializeRootSignature(
+                        &pRootSignatureDesc->Desc_1_0,
+                        D3D_ROOT_SIGNATURE_VERSION_1,
+                        ppBlob,
+                        ppErrorBlob);
+
+                case D3D_ROOT_SIGNATURE_VERSION_1_1: {
+                    HRESULT hr = S_OK;
+                    const D3D12_ROOT_SIGNATURE_DESC1& desc_1_1 = pRootSignatureDesc->Desc_1_1;
+
+                    const SIZE_T ParametersSize = sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters;
+                    void* pParameters = (ParametersSize > 0) ? HeapAlloc(GetProcessHeap(), 0, ParametersSize) : nullptr;
+                    if (ParametersSize > 0 && pParameters == nullptr) {
+                        hr = E_OUTOFMEMORY;
+                    }
+                    auto pParameters_1_0 = static_cast<D3D12_ROOT_PARAMETER*>(pParameters);
+
+                    if (SUCCEEDED(hr)) {
+                        for (UINT n = 0; n < desc_1_1.NumParameters; n++) {
+                            __analysis_assume(ParametersSize == sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters);
+                            pParameters_1_0[n].ParameterType = desc_1_1.pParameters[n].ParameterType;
+                            pParameters_1_0[n].ShaderVisibility = desc_1_1.pParameters[n].ShaderVisibility;
+
+                            switch (desc_1_1.pParameters[n].ParameterType) {
+                                case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
+                                    pParameters_1_0[n].Constants.Num32BitValues =
+                                        desc_1_1.pParameters[n].Constants.Num32BitValues;
+                                    pParameters_1_0[n].Constants.RegisterSpace =
+                                        desc_1_1.pParameters[n].Constants.RegisterSpace;
+                                    pParameters_1_0[n].Constants.ShaderRegister =
+                                        desc_1_1.pParameters[n].Constants.ShaderRegister;
+                                    break;
+
+                                case D3D12_ROOT_PARAMETER_TYPE_CBV:
+                                case D3D12_ROOT_PARAMETER_TYPE_SRV:
+                                case D3D12_ROOT_PARAMETER_TYPE_UAV:
+                                    pParameters_1_0[n].Descriptor.RegisterSpace =
+                                        desc_1_1.pParameters[n].Descriptor.RegisterSpace;
+                                    pParameters_1_0[n].Descriptor.ShaderRegister =
+                                        desc_1_1.pParameters[n].Descriptor.ShaderRegister;
+                                    break;
+
+                                case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
+                                    const D3D12_ROOT_DESCRIPTOR_TABLE1& table_1_1 =
+                                        desc_1_1.pParameters[n].DescriptorTable;
+
+                                    const SIZE_T DescriptorRangesSize =
+                                        sizeof(D3D12_DESCRIPTOR_RANGE) * table_1_1.NumDescriptorRanges;
+                                    void* pDescriptorRanges = (DescriptorRangesSize > 0 && SUCCEEDED(hr))
+                                        ? HeapAlloc(GetProcessHeap(), 0, DescriptorRangesSize)
+                                        : nullptr;
+                                    if (DescriptorRangesSize > 0 && pDescriptorRanges == nullptr) {
+                                        hr = E_OUTOFMEMORY;
+                                    }
+                                    auto pDescriptorRanges_1_0 =
+                                        static_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges);
+
+                                    if (SUCCEEDED(hr)) {
+                                        for (UINT x = 0; x < table_1_1.NumDescriptorRanges; x++) {
+                                            __analysis_assume(
+                                                DescriptorRangesSize ==
+                                                sizeof(D3D12_DESCRIPTOR_RANGE) * table_1_1.NumDescriptorRanges);
+                                            pDescriptorRanges_1_0[x].BaseShaderRegister =
+                                                table_1_1.pDescriptorRanges[x].BaseShaderRegister;
+                                            pDescriptorRanges_1_0[x].NumDescriptors =
+                                                table_1_1.pDescriptorRanges[x].NumDescriptors;
+                                            pDescriptorRanges_1_0[x].OffsetInDescriptorsFromTableStart =
+                                                table_1_1.pDescriptorRanges[x].OffsetInDescriptorsFromTableStart;
+                                            pDescriptorRanges_1_0[x].RangeType =
+                                                table_1_1.pDescriptorRanges[x].RangeType;
+                                            pDescriptorRanges_1_0[x].RegisterSpace =
+                                                table_1_1.pDescriptorRanges[x].RegisterSpace;
+                                        }
+                                    }
+
+                                    D3D12_ROOT_DESCRIPTOR_TABLE& table_1_0 = pParameters_1_0[n].DescriptorTable;
+                                    table_1_0.NumDescriptorRanges = table_1_1.NumDescriptorRanges;
+                                    table_1_0.pDescriptorRanges = pDescriptorRanges_1_0;
+                            }
+                        }
+                    }
+
+                    if (SUCCEEDED(hr)) {
+                        D3D12_ROOT_SIGNATURE_DESC desc_1_0;
+                        InitRootSignatureDesc(
+                            desc_1_0,
+                            desc_1_1.NumParameters,
+                            pParameters_1_0,
+                            desc_1_1.NumStaticSamplers,
+                            desc_1_1.pStaticSamplers,
+                            desc_1_1.Flags);
+                        hr = D3D12SerializeRootSignature(&desc_1_0, D3D_ROOT_SIGNATURE_VERSION_1, ppBlob, ppErrorBlob);
+                    }
+
+                    if (pParameters) {
+                        for (UINT n = 0; n < desc_1_1.NumParameters; n++) {
+                            if (desc_1_1.pParameters[n].ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE) {
+                                HeapFree(
+                                    GetProcessHeap(),
+                                    0,
+                                    reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(
+                                        pParameters_1_0[n].DescriptorTable.pDescriptorRanges)));
+                            }
+                        }
+                        HeapFree(GetProcessHeap(), 0, pParameters);
+                    }
+                    return hr;
+                }
+            }
+            break;
+
+        case D3D_ROOT_SIGNATURE_VERSION_1_1:
+            return D3D12SerializeVersionedRootSignature(pRootSignatureDesc, ppBlob, ppErrorBlob);
+    }
+
+    return E_INVALIDARG;
+}
+
+auto up::d3d12::RootSignatureD3D12::createRootSignature(ID3D12Device* device, const SignatureDesc& desc)
+    -> rc<RootSignatureD3D12> {
+    auto signature = new_shared<RootSignatureD3D12>();
+    signature->create(device, desc);
+    return signature;
+}
+
+auto up::d3d12::RootSignatureD3D12::create(ID3D12Device* device, const SignatureDesc& desc) -> bool {
+    ID3DRootSignaturePtr root;
+    D3D12_FEATURE_DATA_ROOT_SIGNATURE featureData = {};
+
+    // This is the highest version the sample supports. If CheckFeatureSupport succeeds, the HighestVersion returned
+    // will not be greater than this.
+    featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_1;
+
+    if (FAILED(device->CheckFeatureSupport(D3D12_FEATURE_ROOT_SIGNATURE, &featureData, sizeof(featureData)))) {
+        featureData.HighestVersion = D3D_ROOT_SIGNATURE_VERSION_1_0;
+    }
+
+    up::com_ptr<ID3DBlob> signature;
+    up::com_ptr<ID3DBlob> error;
+
+    // Allow input layout and deny unnecessary access to certain pipeline stages.
+    D3D12_ROOT_SIGNATURE_FLAGS rootSignatureFlags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT |
+        D3D12_ROOT_SIGNATURE_FLAG_DENY_DOMAIN_SHADER_ROOT_ACCESS |
+        D3D12_ROOT_SIGNATURE_FLAG_DENY_GEOMETRY_SHADER_ROOT_ACCESS |
+        D3D12_ROOT_SIGNATURE_FLAG_DENY_HULL_SHADER_ROOT_ACCESS;
+
+    D3D12_STATIC_SAMPLER_DESC sampler = {};
+    sampler.Filter = D3D12_FILTER_MIN_MAG_POINT_MIP_LINEAR;
+    sampler.AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    sampler.AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    sampler.AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+    sampler.MipLODBias = 0;
+    sampler.MaxAnisotropy = 0;
+    sampler.ComparisonFunc = D3D12_COMPARISON_FUNC_ALWAYS;
+    sampler.BorderColor = D3D12_STATIC_BORDER_COLOR_TRANSPARENT_BLACK;
+    sampler.MinLOD = 0.0f;
+    sampler.MaxLOD = 0.0f;
+    sampler.ShaderRegister = 0;
+    sampler.RegisterSpace = 0;
+    sampler.ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
+    for (int i = 0; i < RootParamType::RootParamMax; i++) {
+        _offsetMap[i] = desc._offsets[i];
+    }
+
+    D3D12_VERSIONED_ROOT_SIGNATURE_DESC rootSignatureDesc;
+    Init_1_1(
+        rootSignatureDesc,
+        static_cast<uint32>(desc._params.size()),
+        (const D3D12_ROOT_PARAMETER1*)desc._params.data(),
+        0,
+        &sampler,
+        rootSignatureFlags);
+
+    if (FAILED(D3DX12SerializeVersionedRootSignature(
+            &rootSignatureDesc,
+            featureData.HighestVersion,
+            out_ptr(signature),
+            out_ptr(error)))) {
+        auto msg = static_cast<const char*>(error->GetBufferPointer());
+        UP_ASSERT(0, msg);
+        return false;
+    };
+    device->CreateRootSignature(
+        0,
+        signature->GetBufferPointer(),
+        signature->GetBufferSize(),
+        __uuidof(ID3D12RootSignature),
+        out_ptr(_signature));
+
+    UP_ASSERT(signature.get());
+    return true;
+}

--- a/potato/librender/source/d3d12_backend/d3d12_root_signature.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_root_signature.cpp
@@ -6,7 +6,7 @@
 #include "potato/runtime/assertion.h"
 #include "potato/spud/out_ptr.h"
 
-up::d3d12::RootSignatureD3D12::RootSignatureD3D12() {}
+up::d3d12::RootSignatureD3D12::RootSignatureD3D12() { }
 
 up::d3d12::RootSignatureD3D12::~RootSignatureD3D12(){};
 
@@ -104,108 +104,116 @@ inline HRESULT D3DX12SerializeVersionedRootSignature(
                         ppBlob,
                         ppErrorBlob);
 
-                case D3D_ROOT_SIGNATURE_VERSION_1_1: {
-                    HRESULT hr = S_OK;
-                    const D3D12_ROOT_SIGNATURE_DESC1& desc_1_1 = pRootSignatureDesc->Desc_1_1;
+                case D3D_ROOT_SIGNATURE_VERSION_1_1:
+                    {
+                        HRESULT hr = S_OK;
+                        const D3D12_ROOT_SIGNATURE_DESC1& desc_1_1 = pRootSignatureDesc->Desc_1_1;
 
-                    const SIZE_T ParametersSize = sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters;
-                    void* pParameters = (ParametersSize > 0) ? HeapAlloc(GetProcessHeap(), 0, ParametersSize) : nullptr;
-                    if (ParametersSize > 0 && pParameters == nullptr) {
-                        hr = E_OUTOFMEMORY;
-                    }
-                    auto pParameters_1_0 = static_cast<D3D12_ROOT_PARAMETER*>(pParameters);
+                        const SIZE_T ParametersSize = sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters;
+                        void* pParameters =
+                            (ParametersSize > 0) ? HeapAlloc(GetProcessHeap(), 0, ParametersSize) : nullptr;
+                        if (ParametersSize > 0 && pParameters == nullptr) {
+                            hr = E_OUTOFMEMORY;
+                        }
+                        auto pParameters_1_0 = static_cast<D3D12_ROOT_PARAMETER*>(pParameters);
 
-                    if (SUCCEEDED(hr)) {
-                        for (UINT n = 0; n < desc_1_1.NumParameters; n++) {
-                            __analysis_assume(ParametersSize == sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters);
-                            pParameters_1_0[n].ParameterType = desc_1_1.pParameters[n].ParameterType;
-                            pParameters_1_0[n].ShaderVisibility = desc_1_1.pParameters[n].ShaderVisibility;
+                        if (SUCCEEDED(hr)) {
+                            for (UINT n = 0; n < desc_1_1.NumParameters; n++) {
+                                __analysis_assume(
+                                    ParametersSize == sizeof(D3D12_ROOT_PARAMETER) * desc_1_1.NumParameters);
+                                pParameters_1_0[n].ParameterType = desc_1_1.pParameters[n].ParameterType;
+                                pParameters_1_0[n].ShaderVisibility = desc_1_1.pParameters[n].ShaderVisibility;
 
-                            switch (desc_1_1.pParameters[n].ParameterType) {
-                                case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
-                                    pParameters_1_0[n].Constants.Num32BitValues =
-                                        desc_1_1.pParameters[n].Constants.Num32BitValues;
-                                    pParameters_1_0[n].Constants.RegisterSpace =
-                                        desc_1_1.pParameters[n].Constants.RegisterSpace;
-                                    pParameters_1_0[n].Constants.ShaderRegister =
-                                        desc_1_1.pParameters[n].Constants.ShaderRegister;
-                                    break;
+                                switch (desc_1_1.pParameters[n].ParameterType) {
+                                    case D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS:
+                                        pParameters_1_0[n].Constants.Num32BitValues =
+                                            desc_1_1.pParameters[n].Constants.Num32BitValues;
+                                        pParameters_1_0[n].Constants.RegisterSpace =
+                                            desc_1_1.pParameters[n].Constants.RegisterSpace;
+                                        pParameters_1_0[n].Constants.ShaderRegister =
+                                            desc_1_1.pParameters[n].Constants.ShaderRegister;
+                                        break;
 
-                                case D3D12_ROOT_PARAMETER_TYPE_CBV:
-                                case D3D12_ROOT_PARAMETER_TYPE_SRV:
-                                case D3D12_ROOT_PARAMETER_TYPE_UAV:
-                                    pParameters_1_0[n].Descriptor.RegisterSpace =
-                                        desc_1_1.pParameters[n].Descriptor.RegisterSpace;
-                                    pParameters_1_0[n].Descriptor.ShaderRegister =
-                                        desc_1_1.pParameters[n].Descriptor.ShaderRegister;
-                                    break;
+                                    case D3D12_ROOT_PARAMETER_TYPE_CBV:
+                                    case D3D12_ROOT_PARAMETER_TYPE_SRV:
+                                    case D3D12_ROOT_PARAMETER_TYPE_UAV:
+                                        pParameters_1_0[n].Descriptor.RegisterSpace =
+                                            desc_1_1.pParameters[n].Descriptor.RegisterSpace;
+                                        pParameters_1_0[n].Descriptor.ShaderRegister =
+                                            desc_1_1.pParameters[n].Descriptor.ShaderRegister;
+                                        break;
 
-                                case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
-                                    const D3D12_ROOT_DESCRIPTOR_TABLE1& table_1_1 =
-                                        desc_1_1.pParameters[n].DescriptorTable;
+                                    case D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE:
+                                        const D3D12_ROOT_DESCRIPTOR_TABLE1& table_1_1 =
+                                            desc_1_1.pParameters[n].DescriptorTable;
 
-                                    const SIZE_T DescriptorRangesSize =
-                                        sizeof(D3D12_DESCRIPTOR_RANGE) * table_1_1.NumDescriptorRanges;
-                                    void* pDescriptorRanges = (DescriptorRangesSize > 0 && SUCCEEDED(hr))
-                                        ? HeapAlloc(GetProcessHeap(), 0, DescriptorRangesSize)
-                                        : nullptr;
-                                    if (DescriptorRangesSize > 0 && pDescriptorRanges == nullptr) {
-                                        hr = E_OUTOFMEMORY;
-                                    }
-                                    auto pDescriptorRanges_1_0 =
-                                        static_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges);
-
-                                    if (SUCCEEDED(hr)) {
-                                        for (UINT x = 0; x < table_1_1.NumDescriptorRanges; x++) {
-                                            __analysis_assume(
-                                                DescriptorRangesSize ==
-                                                sizeof(D3D12_DESCRIPTOR_RANGE) * table_1_1.NumDescriptorRanges);
-                                            pDescriptorRanges_1_0[x].BaseShaderRegister =
-                                                table_1_1.pDescriptorRanges[x].BaseShaderRegister;
-                                            pDescriptorRanges_1_0[x].NumDescriptors =
-                                                table_1_1.pDescriptorRanges[x].NumDescriptors;
-                                            pDescriptorRanges_1_0[x].OffsetInDescriptorsFromTableStart =
-                                                table_1_1.pDescriptorRanges[x].OffsetInDescriptorsFromTableStart;
-                                            pDescriptorRanges_1_0[x].RangeType =
-                                                table_1_1.pDescriptorRanges[x].RangeType;
-                                            pDescriptorRanges_1_0[x].RegisterSpace =
-                                                table_1_1.pDescriptorRanges[x].RegisterSpace;
+                                        const SIZE_T DescriptorRangesSize =
+                                            sizeof(D3D12_DESCRIPTOR_RANGE) * table_1_1.NumDescriptorRanges;
+                                        void* pDescriptorRanges = (DescriptorRangesSize > 0 && SUCCEEDED(hr))
+                                            ? HeapAlloc(GetProcessHeap(), 0, DescriptorRangesSize)
+                                            : nullptr;
+                                        if (DescriptorRangesSize > 0 && pDescriptorRanges == nullptr) {
+                                            hr = E_OUTOFMEMORY;
                                         }
-                                    }
+                                        auto pDescriptorRanges_1_0 =
+                                            static_cast<D3D12_DESCRIPTOR_RANGE*>(pDescriptorRanges);
 
-                                    D3D12_ROOT_DESCRIPTOR_TABLE& table_1_0 = pParameters_1_0[n].DescriptorTable;
-                                    table_1_0.NumDescriptorRanges = table_1_1.NumDescriptorRanges;
-                                    table_1_0.pDescriptorRanges = pDescriptorRanges_1_0;
+                                        if (SUCCEEDED(hr)) {
+                                            for (UINT x = 0; x < table_1_1.NumDescriptorRanges; x++) {
+                                                __analysis_assume(
+                                                    DescriptorRangesSize ==
+                                                    sizeof(D3D12_DESCRIPTOR_RANGE) * table_1_1.NumDescriptorRanges);
+                                                pDescriptorRanges_1_0[x].BaseShaderRegister =
+                                                    table_1_1.pDescriptorRanges[x].BaseShaderRegister;
+                                                pDescriptorRanges_1_0[x].NumDescriptors =
+                                                    table_1_1.pDescriptorRanges[x].NumDescriptors;
+                                                pDescriptorRanges_1_0[x].OffsetInDescriptorsFromTableStart =
+                                                    table_1_1.pDescriptorRanges[x].OffsetInDescriptorsFromTableStart;
+                                                pDescriptorRanges_1_0[x].RangeType =
+                                                    table_1_1.pDescriptorRanges[x].RangeType;
+                                                pDescriptorRanges_1_0[x].RegisterSpace =
+                                                    table_1_1.pDescriptorRanges[x].RegisterSpace;
+                                            }
+                                        }
+
+                                        D3D12_ROOT_DESCRIPTOR_TABLE& table_1_0 = pParameters_1_0[n].DescriptorTable;
+                                        table_1_0.NumDescriptorRanges = table_1_1.NumDescriptorRanges;
+                                        table_1_0.pDescriptorRanges = pDescriptorRanges_1_0;
+                                }
                             }
                         }
-                    }
 
-                    if (SUCCEEDED(hr)) {
-                        D3D12_ROOT_SIGNATURE_DESC desc_1_0;
-                        InitRootSignatureDesc(
-                            desc_1_0,
-                            desc_1_1.NumParameters,
-                            pParameters_1_0,
-                            desc_1_1.NumStaticSamplers,
-                            desc_1_1.pStaticSamplers,
-                            desc_1_1.Flags);
-                        hr = D3D12SerializeRootSignature(&desc_1_0, D3D_ROOT_SIGNATURE_VERSION_1, ppBlob, ppErrorBlob);
-                    }
-
-                    if (pParameters) {
-                        for (UINT n = 0; n < desc_1_1.NumParameters; n++) {
-                            if (desc_1_1.pParameters[n].ParameterType == D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE) {
-                                HeapFree(
-                                    GetProcessHeap(),
-                                    0,
-                                    reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(
-                                        pParameters_1_0[n].DescriptorTable.pDescriptorRanges)));
-                            }
+                        if (SUCCEEDED(hr)) {
+                            D3D12_ROOT_SIGNATURE_DESC desc_1_0;
+                            InitRootSignatureDesc(
+                                desc_1_0,
+                                desc_1_1.NumParameters,
+                                pParameters_1_0,
+                                desc_1_1.NumStaticSamplers,
+                                desc_1_1.pStaticSamplers,
+                                desc_1_1.Flags);
+                            hr = D3D12SerializeRootSignature(
+                                &desc_1_0,
+                                D3D_ROOT_SIGNATURE_VERSION_1,
+                                ppBlob,
+                                ppErrorBlob);
                         }
-                        HeapFree(GetProcessHeap(), 0, pParameters);
+
+                        if (pParameters) {
+                            for (UINT n = 0; n < desc_1_1.NumParameters; n++) {
+                                if (desc_1_1.pParameters[n].ParameterType ==
+                                    D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE) {
+                                    HeapFree(
+                                        GetProcessHeap(),
+                                        0,
+                                        reinterpret_cast<void*>(const_cast<D3D12_DESCRIPTOR_RANGE*>(
+                                            pParameters_1_0[n].DescriptorTable.pDescriptorRanges)));
+                                }
+                            }
+                            HeapFree(GetProcessHeap(), 0, pParameters);
+                        }
+                        return hr;
                     }
-                    return hr;
-                }
             }
             break;
 

--- a/potato/librender/source/d3d12_backend/d3d12_root_signature.h
+++ b/potato/librender/source/d3d12_backend/d3d12_root_signature.h
@@ -1,0 +1,191 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_pipeline_state.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/rc.h"
+#include "potato/spud/vector.h"
+
+namespace up::d3d12 {
+
+    class CommandListD3D12;
+    class DescriptorHeapD3D12;
+
+    enum RootParamType : uint32 { Texture, Sampler, ConstValues, ConstBuffer, RootParamMax };
+
+    struct SignatureParam {
+        D3D12_ROOT_PARAMETER1 _parameter;
+
+        void initRootDescriptor(
+            _Out_ D3D12_ROOT_DESCRIPTOR1& table,
+            UINT shaderRegister,
+            UINT registerSpace = 0,
+            D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE) noexcept {
+            table.ShaderRegister = shaderRegister;
+            table.RegisterSpace = registerSpace;
+            table.Flags = flags;
+        }
+
+        void initRootDescriptorTable(
+            _Out_ D3D12_ROOT_DESCRIPTOR_TABLE1& rootDescriptorTable,
+            UINT numDescriptorRanges,
+            _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges) noexcept {
+            rootDescriptorTable.NumDescriptorRanges = numDescriptorRanges;
+            rootDescriptorTable.pDescriptorRanges = _pDescriptorRanges;
+        }
+
+        void initRootConstant(
+            _Out_ D3D12_ROOT_CONSTANTS& rootConstants,
+            UINT num32BitValues,
+            UINT shaderRegister,
+            UINT registerSpace = 0) noexcept {
+            rootConstants.Num32BitValues = num32BitValues;
+            rootConstants.ShaderRegister = shaderRegister;
+            rootConstants.RegisterSpace = registerSpace;
+        }
+
+        void initRootDescriptorTable1(
+            _Out_ D3D12_ROOT_DESCRIPTOR_TABLE1& rootDescriptorTable,
+            UINT numDescriptorRanges,
+            _In_reads_opt_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* _pDescriptorRanges) noexcept {
+            rootDescriptorTable.NumDescriptorRanges = numDescriptorRanges;
+            rootDescriptorTable.pDescriptorRanges = _pDescriptorRanges;
+        }
+        void initAsDescriptorTable(
+            UINT numDescriptorRanges,
+            _In_reads_(numDescriptorRanges) const D3D12_DESCRIPTOR_RANGE1* pDescriptorRanges,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept {
+            _parameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+            _parameter.ShaderVisibility = visibility;
+            initRootDescriptorTable(_parameter.DescriptorTable, numDescriptorRanges, pDescriptorRanges);
+        }
+
+        void initAsConstants(
+            UINT num32BitValues,
+            UINT shaderRegister,
+            UINT registerSpace = 0,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept {
+            _parameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_32BIT_CONSTANTS;
+            _parameter.ShaderVisibility = visibility;
+            initRootConstant(_parameter.Constants, num32BitValues, shaderRegister, registerSpace);
+        }
+
+        void initAsConstantBufferView(
+            UINT shaderRegister,
+            UINT registerSpace = 0,
+            D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept {
+            _parameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+            _parameter.ShaderVisibility = visibility;
+            initRootDescriptor(_parameter.Descriptor, shaderRegister, registerSpace, flags);
+        }
+
+        void initAsShaderResourceView(
+            UINT shaderRegister,
+            UINT registerSpace = 0,
+            D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept {
+            _parameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_SRV;
+            _parameter.ShaderVisibility = visibility;
+            initRootDescriptor(_parameter.Descriptor, shaderRegister, registerSpace, flags);
+        }
+
+        void initAsUnorderedAccessView(
+            UINT shaderRegister,
+            UINT registerSpace = 0,
+            D3D12_ROOT_DESCRIPTOR_FLAGS flags = D3D12_ROOT_DESCRIPTOR_FLAG_NONE,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) noexcept {
+            _parameter.ParameterType = D3D12_ROOT_PARAMETER_TYPE_UAV;
+            _parameter.ShaderVisibility = visibility;
+            initRootDescriptor(_parameter.Descriptor, shaderRegister, registerSpace, flags);
+        }
+    };
+
+    struct SignatureRange {
+        D3D12_DESCRIPTOR_RANGE1 _range;
+
+        void initRange(
+            D3D12_DESCRIPTOR_RANGE_TYPE rangeType,
+            UINT numDescriptors,
+            UINT baseShaderRegister,
+            UINT registerSpace = 0,
+            D3D12_DESCRIPTOR_RANGE_FLAGS flags = D3D12_DESCRIPTOR_RANGE_FLAG_NONE,
+            UINT offsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND) noexcept {
+            _range.RangeType = rangeType;
+            _range.NumDescriptors = numDescriptors;
+            _range.BaseShaderRegister = baseShaderRegister;
+            _range.RegisterSpace = registerSpace;
+            _range.Flags = flags;
+            _range.OffsetInDescriptorsFromTableStart = offsetInDescriptorsFromTableStart;
+        }
+    };
+
+    struct SignatureDesc {
+        vector<SignatureParam> _params;
+        vector<SignatureRange> _range;
+        uint32 _offsets[RootParamType::RootParamMax];
+
+        void resize(uint32 params) {
+            _params.resize(params);
+            _range.resize(2);
+            memset(&_offsets[0], 0xff, sizeof(_offsets));
+        }
+
+        void initSamplers(
+            uint32 offset,
+            uint32 count,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) {
+            _range[1].initRange(D3D12_DESCRIPTOR_RANGE_TYPE_SAMPLER, count, 0, 0);
+            _params[offset].initAsDescriptorTable(1, &_range[1]._range, visibility);
+            _offsets[RootParamType::Sampler] = offset;
+        }
+        void initSRVs(uint32 offset, uint32 count, D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) {
+            _range[0].initRange(D3D12_DESCRIPTOR_RANGE_TYPE_SRV, count, 0, 0);
+            _params[offset].initAsDescriptorTable(1, &_range[0]._range, visibility);
+            _offsets[RootParamType::Texture] = offset;
+        }
+        void initConstValues(
+            uint32 offset,
+            uint32 count,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) {
+            _params[offset].initAsConstants(count, 0, 0, visibility);
+            _offsets[RootParamType::ConstValues] = offset;
+        }
+        void initConstBuffer(
+            uint32 offset,
+            uint32 reg,
+            D3D12_SHADER_VISIBILITY visibility = D3D12_SHADER_VISIBILITY_ALL) {
+            _params[offset].initAsConstantBufferView(reg, 0, D3D12_ROOT_DESCRIPTOR_FLAG_NONE, visibility);
+            if (_offsets[RootParamType::ConstBuffer] == 0xffffffff) {
+                _offsets[RootParamType::ConstBuffer] = offset;
+            }
+        }
+    };
+
+    class RootSignatureD3D12 : public shared<RootSignatureD3D12> {
+    public:
+        explicit RootSignatureD3D12();
+        virtual ~RootSignatureD3D12();
+
+        // placeholder management of different root managers
+        // @todo: come up with better way of managing root signatures during runtime
+        static bool initializeSignatures(ID3D12Device* device);
+        static bool destroySignatures();
+        static rc<RootSignatureD3D12> getRootSignature(RootSignatureType type);
+
+        static rc<RootSignatureD3D12> createRootSignature(ID3D12Device* device, const SignatureDesc& desc);
+
+        ID3D12RootSignature* signature() const { return _signature.get(); }
+        uint32 getRootOffset(RootParamType type) const { return _offsetMap[type]; }
+
+    private:
+        bool create(ID3D12Device* device, const SignatureDesc& desc);
+
+    private:
+        uint32 _offsetMap[RootParamType::RootParamMax];
+        ID3DRootSignaturePtr _signature;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_sampler.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_sampler.cpp
@@ -2,7 +2,7 @@
 
 #include "d3d12_sampler.h"
 
-up::d3d12::SamplerD3D12::SamplerD3D12() {}
+up::d3d12::SamplerD3D12::SamplerD3D12() { }
 
 up::d3d12::SamplerD3D12::~SamplerD3D12() = default;
 

--- a/potato/librender/source/d3d12_backend/d3d12_sampler.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_sampler.cpp
@@ -1,0 +1,12 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_sampler.h"
+
+up::d3d12::SamplerD3D12::SamplerD3D12() {}
+
+up::d3d12::SamplerD3D12::~SamplerD3D12() = default;
+
+auto up::d3d12::SamplerD3D12::create(const D3D12_GPU_DESCRIPTOR_HANDLE& descriptor) -> bool {
+    _descriptor = descriptor;
+    return true;
+}

--- a/potato/librender/source/d3d12_backend/d3d12_sampler.h
+++ b/potato/librender/source/d3d12_backend/d3d12_sampler.h
@@ -1,0 +1,26 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_sampler.h"
+#include "potato/runtime/com_ptr.h"
+
+namespace up::d3d12 {
+    class SamplerD3D12 final : public GpuSampler {
+    public:
+        explicit SamplerD3D12();
+        virtual ~SamplerD3D12();
+
+        SamplerD3D12(SamplerD3D12&&) = delete;
+        SamplerD3D12& operator=(SamplerD3D12&&) = delete;
+
+        bool create(const D3D12_GPU_DESCRIPTOR_HANDLE& descriptor);
+
+        const D3D12_GPU_DESCRIPTOR_HANDLE& desc() const { return _descriptor; }
+
+    private:
+        D3D12_GPU_DESCRIPTOR_HANDLE _descriptor;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_swap_chain.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_swap_chain.cpp
@@ -1,13 +1,12 @@
 // Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
 
 #include "d3d12_swap_chain.h"
-#include "d3d12_desc_heap.h"
-#include "d3d12_platform.h"
-#include "d3d12_texture.h"
-#include "d3d12_resource_view.h"
-#include "d3d12_device.h"
-
 #include "d3d12_command_list.h"
+#include "d3d12_desc_heap.h"
+#include "d3d12_device.h"
+#include "d3d12_platform.h"
+#include "d3d12_resource_view.h"
+#include "d3d12_texture.h"
 
 #include "potato/runtime/com_ptr.h"
 #include "potato/spud/box.h"
@@ -20,8 +19,7 @@ auto up::d3d12::SwapChainD3D12::createSwapChain(
     ID3DDeviceType* device,
     ID3D12CommandQueue* queue,
     DescriptorHeapD3D12* descHeap,
-    void* nativeWindow)
-    -> rc<GpuSwapChain> {
+    void* nativeWindow) -> rc<GpuSwapChain> {
     auto swapchain = new_shared<SwapChainD3D12>();
     swapchain->create(factory, device, queue, descHeap, nativeWindow);
     return swapchain;
@@ -33,7 +31,6 @@ auto up::d3d12::SwapChainD3D12::create(
     ID3D12CommandQueue* queue,
     DescriptorHeapD3D12* descHeap,
     void* nativeWindow) -> bool {
-
     DXGI_SWAP_CHAIN_DESC1 desc = {0};
     desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
     desc.SampleDesc.Count = 1;
@@ -51,7 +48,7 @@ auto up::d3d12::SwapChainD3D12::create(
     if (FAILED(hr) || swapChain == nullptr) {
         return false;
     }
-   _swapChain = swapChain.as<IDXGISwapChainType>();
+    _swapChain = swapChain.as<IDXGISwapChainType>();
 
     factory->MakeWindowAssociation(window, DXGI_MWA_NO_ALT_ENTER);
 
@@ -98,7 +95,8 @@ void up::d3d12::SwapChainD3D12::unbind(GpuCommandList* cmd) {
     // Indicate that the back buffer will be used as a render target.
     D3D12_RESOURCE_BARRIER barrier = InitTransitionBarrier(
         _backBuffer[_bufferIndex].get(),
-        D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
+        D3D12_RESOURCE_STATE_RENDER_TARGET,
+        D3D12_RESOURCE_STATE_PRESENT);
     cl->getResource()->ResourceBarrier(1, &barrier);
 }
 
@@ -108,12 +106,12 @@ void up::d3d12::SwapChainD3D12::present() {
 }
 
 void up::d3d12::SwapChainD3D12::resizeBuffers(GpuDevice& device, int width, int height) {
-
     for (uint32 i = 0; i < kNumFrames; i++) {
         _backBuffer[i].reset();
     }
 
-    _swapChain->ResizeBuffers(kNumFrames, width, height, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+    _swapChain
+        ->ResizeBuffers(kNumFrames, width, height, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
 
     initBackBufferTargets(static_cast<DeviceD3D12&>(device).getDevice());
 

--- a/potato/librender/source/d3d12_backend/d3d12_swap_chain.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_swap_chain.cpp
@@ -1,0 +1,143 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_swap_chain.h"
+#include "d3d12_desc_heap.h"
+#include "d3d12_platform.h"
+#include "d3d12_texture.h"
+#include "d3d12_resource_view.h"
+#include "d3d12_device.h"
+
+#include "d3d12_command_list.h"
+
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+#include "potato/spud/out_ptr.h"
+
+#include <utility>
+
+auto up::d3d12::SwapChainD3D12::createSwapChain(
+    IDXGIFactoryType* factory,
+    ID3DDeviceType* device,
+    ID3D12CommandQueue* queue,
+    DescriptorHeapD3D12* descHeap,
+    void* nativeWindow)
+    -> rc<GpuSwapChain> {
+    auto swapchain = new_shared<SwapChainD3D12>();
+    swapchain->create(factory, device, queue, descHeap, nativeWindow);
+    return swapchain;
+}
+
+auto up::d3d12::SwapChainD3D12::create(
+    IDXGIFactoryType* factory,
+    ID3D12Device* device,
+    ID3D12CommandQueue* queue,
+    DescriptorHeapD3D12* descHeap,
+    void* nativeWindow) -> bool {
+
+    DXGI_SWAP_CHAIN_DESC1 desc = {0};
+    desc.Format = DXGI_FORMAT_R8G8B8A8_UNORM;
+    desc.SampleDesc.Count = 1;
+    desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+    desc.BufferCount = kNumFrames;
+    desc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
+    desc.Scaling = DXGI_SCALING_STRETCH;
+    desc.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+    desc.Flags = DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING;
+
+    HWND window = static_cast<HWND>(nativeWindow);
+
+    com_ptr<IDXGISwapChain1> swapChain;
+    HRESULT hr = factory->CreateSwapChainForHwnd(queue, window, &desc, nullptr, nullptr, out_ptr(swapChain));
+    if (FAILED(hr) || swapChain == nullptr) {
+        return false;
+    }
+   _swapChain = swapChain.as<IDXGISwapChainType>();
+
+    factory->MakeWindowAssociation(window, DXGI_MWA_NO_ALT_ENTER);
+
+    _descHeap = descHeap;
+
+    initBackBufferTargets(device);
+
+    return true;
+}
+
+static inline D3D12_RESOURCE_BARRIER InitTransitionBarrier(
+    _In_ ID3D12Resource* pResource,
+    D3D12_RESOURCE_STATES stateBefore,
+    D3D12_RESOURCE_STATES stateAfter,
+    UINT subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES,
+    D3D12_RESOURCE_BARRIER_FLAGS flags = D3D12_RESOURCE_BARRIER_FLAG_NONE) noexcept {
+    D3D12_RESOURCE_BARRIER result = {};
+    result.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    result.Flags = flags;
+    result.Transition.pResource = pResource;
+    result.Transition.StateBefore = stateBefore;
+    result.Transition.StateAfter = stateAfter;
+    result.Transition.Subresource = subresource;
+    return result;
+}
+
+void up::d3d12::SwapChainD3D12::bind(GpuCommandList* cmd) {
+    auto cl = static_cast<CommandListD3D12*>(cmd);
+
+    // Indicate that the back buffer will be used as a render target.
+    D3D12_RESOURCE_BARRIER barrier = InitTransitionBarrier(
+        _backBuffer[_bufferIndex].get(),
+        D3D12_RESOURCE_STATE_PRESENT,
+        D3D12_RESOURCE_STATE_RENDER_TARGET);
+    cl->getResource()->ResourceBarrier(1, &barrier);
+
+    D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle{_descHeap->get_cpu(_bufferIndex)};
+    cl->getResource()->OMSetRenderTargets(1, &rtvHandle, FALSE, nullptr);
+};
+
+void up::d3d12::SwapChainD3D12::unbind(GpuCommandList* cmd) {
+    auto cl = static_cast<CommandListD3D12*>(cmd);
+
+    // Indicate that the back buffer will be used as a render target.
+    D3D12_RESOURCE_BARRIER barrier = InitTransitionBarrier(
+        _backBuffer[_bufferIndex].get(),
+        D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
+    cl->getResource()->ResourceBarrier(1, &barrier);
+}
+
+void up::d3d12::SwapChainD3D12::present() {
+    _swapChain->Present(0, DXGI_PRESENT_ALLOW_TEARING);
+    _bufferIndex = _swapChain->GetCurrentBackBufferIndex();
+}
+
+void up::d3d12::SwapChainD3D12::resizeBuffers(GpuDevice& device, int width, int height) {
+
+    for (uint32 i = 0; i < kNumFrames; i++) {
+        _backBuffer[i].reset();
+    }
+
+    _swapChain->ResizeBuffers(kNumFrames, width, height, DXGI_FORMAT_R8G8B8A8_UNORM, DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING);
+
+    initBackBufferTargets(static_cast<DeviceD3D12&>(device).getDevice());
+
+    _bufferIndex = _swapChain->GetCurrentBackBufferIndex();
+}
+
+auto up::d3d12::SwapChainD3D12::getBuffer(int index) -> rc<GpuTexture> {
+    ID3DResourcePtr buffer;
+    _swapChain->GetBuffer(_bufferIndex, __uuidof(ID3D12Resource), out_ptr(buffer));
+    if (buffer == nullptr) {
+        return nullptr;
+    }
+    return new_shared<TextureD3D12>(std::move(buffer));
+}
+
+int up::d3d12::SwapChainD3D12::getCurrentBufferIndex() {
+    return _bufferIndex;
+}
+
+void up::d3d12::SwapChainD3D12::initBackBufferTargets(ID3D12Device* device) {
+    for (uint32 i = 0; i < kNumFrames; i++) {
+        _swapChain->GetBuffer(i, __uuidof(ID3D12Resource), out_ptr(_backBuffer[i]));
+        device->CreateRenderTargetView(_backBuffer[i].get(), nullptr, _descHeap->get_cpu(i));
+    }
+
+    _bufferIndex = _swapChain->GetCurrentBackBufferIndex();
+}

--- a/potato/librender/source/d3d12_backend/d3d12_swap_chain.h
+++ b/potato/librender/source/d3d12_backend/d3d12_swap_chain.h
@@ -1,0 +1,53 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_swap_chain.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+
+namespace up::d3d12 {
+    class DescriptorHeapD3D12;
+
+    class SwapChainD3D12 : public GpuSwapChain {
+    public:
+        SwapChainD3D12() = default;
+        virtual ~SwapChainD3D12() = default;
+
+        SwapChainD3D12(SwapChainD3D12&&) = delete;
+        SwapChainD3D12& operator=(SwapChainD3D12&&) = delete;
+
+        static rc<GpuSwapChain> createSwapChain(
+            IDXGIFactoryType* factory,
+            ID3D12Device* device,
+            ID3D12CommandQueue* queue,
+            DescriptorHeapD3D12* descHeap,
+            void* nativeWindow);
+
+        bool create(
+            IDXGIFactoryType* factory,
+            ID3D12Device* device,
+            ID3D12CommandQueue* queue,
+            DescriptorHeapD3D12* descHeap,
+            void* nativeWindow);
+        void bind(GpuCommandList* cmd) override;
+        void unbind(GpuCommandList* cmd) override;
+        void present() override;
+        void resizeBuffers(GpuDevice& device, int width, int height) override;
+        rc<GpuTexture> getBuffer(int index) override;
+        int getCurrentBufferIndex() override;
+
+    protected:
+        void initBackBufferTargets(ID3D12Device* device);
+
+    private:
+        static const up::uint32 kNumFrames = 2;
+
+        IDXGISwapChainPtr _swapChain;
+        uint32 _bufferIndex = 0;
+        ID3DResourcePtr _backBuffer[kNumFrames];
+        DescriptorHeapD3D12* _descHeap = nullptr;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_texture.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_texture.cpp
@@ -1,0 +1,256 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#include "d3d12_texture.h"
+#include "d3d12_command_list.h"
+#include "d3d12_platform.h"
+#include "d3d12_utils.h"
+#include "d3d12_desc_heap.h"
+#include "d3d12_device.h"
+
+#include "potato/runtime/assertion.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/out_ptr.h"
+
+#include <d3d12.h>
+
+up::d3d12::TextureD3D12::TextureD3D12() {}
+
+up::d3d12::TextureD3D12::TextureD3D12(ID3DResourcePtr buffer) : _texture(buffer) {}
+
+
+namespace ResourceDesc { 
+static inline D3D12_RESOURCE_DESC ResourceDesc(
+    D3D12_RESOURCE_DIMENSION dimension,
+    UINT64 alignment,
+    UINT64 width,
+    UINT height,
+    UINT16 depthOrArraySize,
+    UINT16 mipLevels,
+    DXGI_FORMAT format,
+    UINT sampleCount,
+    UINT sampleQuality,
+    D3D12_TEXTURE_LAYOUT layout,
+    D3D12_RESOURCE_FLAGS flags) {
+
+    D3D12_RESOURCE_DESC desc = {};
+    desc.Dimension = dimension;
+    desc.Alignment = alignment;
+    desc.Width = width;
+    desc.Height = height;
+    desc.DepthOrArraySize = depthOrArraySize;
+    desc.MipLevels = mipLevels;
+    desc.Format = format;
+    desc.SampleDesc.Count = sampleCount;
+    desc.SampleDesc.Quality = sampleQuality;
+    desc.Layout = layout;
+    desc.Flags = flags;
+    return desc; 
+}
+
+ static inline D3D12_RESOURCE_DESC Buffer(
+    UINT64 width,
+    D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+    UINT64 alignment = 0) noexcept {
+    return ResourceDesc(
+        D3D12_RESOURCE_DIMENSION_BUFFER,
+        alignment,
+        width,
+        1,
+        1,
+        1,
+        DXGI_FORMAT_UNKNOWN,
+        1,
+        0,
+        D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+        flags);
+}
+
+ static inline D3D12_RESOURCE_DESC Tex2D(
+    DXGI_FORMAT format,
+    UINT64 width,
+    UINT height,
+    UINT16 arraySize = 1,
+    UINT16 mipLevels = 0,
+    UINT sampleCount = 1,
+    UINT sampleQuality = 0,
+    D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+    D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
+    UINT64 alignment = 0) noexcept {
+    return ResourceDesc(
+        D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+        alignment,
+        width,
+        height,
+        arraySize,
+        mipLevels,
+        format,
+        sampleCount,
+        sampleQuality,
+        layout,
+        flags);
+}
+} // namespace ResourceDesc
+
+auto up::d3d12::TextureD3D12::create(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc, span<up::byte const> data)
+    -> bool {
+    if (desc.type == GpuTextureType::Texture2D) {
+        return create2DTex(ctx, desc, data);
+    }
+    if (desc.type == GpuTextureType::DepthStencil) {
+        return createDepthStencilTex(ctx, desc);
+    }
+
+     UP_UNREACHABLE("Unsupported texture type");
+    return false; 
+}
+
+auto up::d3d12::TextureD3D12::create2DTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc, span<up::byte const> data)
+        ->bool {
+    _format = toNative(desc.format);
+    D3D12_RESOURCE_DESC resourceDesc = ResourceDesc::Tex2D(_format, desc.width, desc.height, 1, 1);
+
+    D3D12MA::ALLOCATION_DESC allocDesc = {};
+    allocDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+
+    ctx.allocator()->CreateResource(
+        &allocDesc,
+        &resourceDesc,
+        D3D12_RESOURCE_STATE_COPY_DEST,
+        NULL,
+        out_ptr(_allocation),
+        __uuidof(ID3D12Resource),
+        out_ptr(_texture));
+
+    if (data.size() != 0) {
+        uploadData(ctx, resourceDesc, data);
+    }
+
+    return true;
+}
+
+auto up::d3d12::TextureD3D12::createDepthStencilTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc)
+        ->bool {
+    _format = toNative(desc.format);
+    D3D12_RESOURCE_DESC resourceDesc =
+        ResourceDesc::Tex2D(_format, desc.width, desc.height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
+
+    D3D12MA::ALLOCATION_DESC allocDesc = {};
+    allocDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
+
+    D3D12_CLEAR_VALUE depthOptimizedClearValue = {};
+    depthOptimizedClearValue.Format = _format;
+    depthOptimizedClearValue.DepthStencil.Depth = 1.0f;
+    depthOptimizedClearValue.DepthStencil.Stencil = 0;
+
+    ctx.allocator()->CreateResource(
+        &allocDesc,
+        &resourceDesc,
+        D3D12_RESOURCE_STATE_DEPTH_WRITE,
+        &depthOptimizedClearValue,
+        out_ptr(_allocation),
+        __uuidof(ID3D12Resource),
+        out_ptr(_texture));
+
+    return true;
+}
+
+
+auto up::d3d12::TextureD3D12::uploadData(RenderContextD3D12 const& ctx, D3D12_RESOURCE_DESC& resourceDesc, span<up::byte const> data)
+    -> bool {
+
+    uint32 stride = static_cast<uint32>(resourceDesc.Width * toByteSize(fromNative(resourceDesc.Format)));
+
+    UINT64 textureUploadBufferSize = 0;
+    static_cast<DeviceD3D12*>(ctx.device())->getDevice()->GetCopyableFootprints(
+        &resourceDesc,
+        0, // FirstSubresource
+        1, // NumSubresources
+        0, // BaseOffset
+        nullptr, // pLayouts
+        nullptr, // pNumRows
+        nullptr, // pRowSizeInBytes
+        &textureUploadBufferSize); // pTotalBytes
+
+
+    D3D12MA::ALLOCATION_DESC uploadAllocDesc = {};
+    uploadAllocDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;
+
+    D3D12_RESOURCE_DESC uploadBufferDesc = ResourceDesc::Buffer(textureUploadBufferSize);
+
+    ctx.allocator()->CreateResource(
+        &uploadAllocDesc,
+        &uploadBufferDesc,
+        D3D12_RESOURCE_STATE_GENERIC_READ,
+        nullptr, // pOptimizedClearValue
+        out_ptr(_uploadAlloc),
+        __uuidof(ID3D12Resource),
+        out_ptr(_uploadTexture));
+    _uploadTexture->SetName(L"textureUpload");
+
+    D3D12_SUBRESOURCE_DATA textureSubresourceData = {};
+    textureSubresourceData.pData = data.data();
+    textureSubresourceData.RowPitch = stride;
+    textureSubresourceData.SlicePitch = stride * resourceDesc.Height;
+
+    UpdateSubresources(
+        static_cast<DeviceD3D12*>(ctx.device())->getDevice(),
+        ctx.cmdList()->getResource(),
+        _texture.get(),
+        _uploadTexture.get(),
+        0,
+        0,
+        1,
+        &textureSubresourceData);
+
+    D3D12_RESOURCE_BARRIER textureBarrier = {};
+    textureBarrier.Type = D3D12_RESOURCE_BARRIER_TYPE_TRANSITION;
+    textureBarrier.Transition.pResource = _texture.get();
+    textureBarrier.Transition.StateBefore = D3D12_RESOURCE_STATE_COPY_DEST;
+    textureBarrier.Transition.StateAfter = D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE;
+    textureBarrier.Transition.Subresource = D3D12_RESOURCE_BARRIER_ALL_SUBRESOURCES;
+
+    ctx.cmdList()->getResource()->ResourceBarrier(1, &textureBarrier);
+
+    return true;
+}
+
+auto up::d3d12::TextureD3D12::type() const noexcept -> GpuTextureType {
+    com_ptr<ID3D12Resource> texture2D;
+    if (SUCCEEDED(_texture->QueryInterface(__uuidof(ID3D12Resource), out_ptr(texture2D)))) {
+        D3D12_RESOURCE_DESC desc = texture2D->GetDesc();
+        switch (desc.Dimension) {
+            case D3D12_RESOURCE_DIMENSION_TEXTURE2D:
+                return GpuTextureType::Texture2D;
+            case D3D12_RESOURCE_DIMENSION_TEXTURE3D:
+                return GpuTextureType::Texture3D;
+        }
+    }
+
+    UP_UNREACHABLE("could not detect texture type");
+    return GpuTextureType::Texture2D;
+}
+
+auto up::d3d12::TextureD3D12::format() const noexcept -> GpuFormat {
+    return fromNative(nativeFormat());
+}
+
+DXGI_FORMAT up::d3d12::TextureD3D12::nativeFormat() const noexcept {
+    com_ptr<ID3D12Resource> texture2D;
+    if (SUCCEEDED(_texture->QueryInterface(__uuidof(ID3D12Resource), out_ptr(texture2D)))) {
+        D3D12_RESOURCE_DESC desc = texture2D->GetDesc();
+        return desc.Format;
+    }
+    return DXGI_FORMAT_UNKNOWN;
+}
+
+auto up::d3d12::TextureD3D12::dimensions() const noexcept -> glm::ivec3 {
+    com_ptr<ID3D12Resource> texture2D;
+    if (SUCCEEDED(_texture->QueryInterface(__uuidof(ID3D12Resource), out_ptr(texture2D)))) {
+        D3D12_RESOURCE_DESC desc = texture2D->GetDesc();
+        return {desc.Width, desc.Height, 0};
+    }
+
+    UP_UNREACHABLE("could not detect texture type");
+    return {0, 0, 0};
+}

--- a/potato/librender/source/d3d12_backend/d3d12_texture.cpp
+++ b/potato/librender/source/d3d12_backend/d3d12_texture.cpp
@@ -2,10 +2,10 @@
 
 #include "d3d12_texture.h"
 #include "d3d12_command_list.h"
-#include "d3d12_platform.h"
-#include "d3d12_utils.h"
 #include "d3d12_desc_heap.h"
 #include "d3d12_device.h"
+#include "d3d12_platform.h"
+#include "d3d12_utils.h"
 
 #include "potato/runtime/assertion.h"
 #include "potato/runtime/com_ptr.h"
@@ -13,86 +13,86 @@
 
 #include <d3d12.h>
 
-up::d3d12::TextureD3D12::TextureD3D12() {}
+up::d3d12::TextureD3D12::TextureD3D12() { }
 
-up::d3d12::TextureD3D12::TextureD3D12(ID3DResourcePtr buffer) : _texture(buffer) {}
+up::d3d12::TextureD3D12::TextureD3D12(ID3DResourcePtr buffer) : _texture(buffer) { }
 
+namespace ResourceDesc {
+    static inline D3D12_RESOURCE_DESC ResourceDesc(
+        D3D12_RESOURCE_DIMENSION dimension,
+        UINT64 alignment,
+        UINT64 width,
+        UINT height,
+        UINT16 depthOrArraySize,
+        UINT16 mipLevels,
+        DXGI_FORMAT format,
+        UINT sampleCount,
+        UINT sampleQuality,
+        D3D12_TEXTURE_LAYOUT layout,
+        D3D12_RESOURCE_FLAGS flags) {
+        D3D12_RESOURCE_DESC desc = {};
+        desc.Dimension = dimension;
+        desc.Alignment = alignment;
+        desc.Width = width;
+        desc.Height = height;
+        desc.DepthOrArraySize = depthOrArraySize;
+        desc.MipLevels = mipLevels;
+        desc.Format = format;
+        desc.SampleDesc.Count = sampleCount;
+        desc.SampleDesc.Quality = sampleQuality;
+        desc.Layout = layout;
+        desc.Flags = flags;
+        return desc;
+    }
 
-namespace ResourceDesc { 
-static inline D3D12_RESOURCE_DESC ResourceDesc(
-    D3D12_RESOURCE_DIMENSION dimension,
-    UINT64 alignment,
-    UINT64 width,
-    UINT height,
-    UINT16 depthOrArraySize,
-    UINT16 mipLevels,
-    DXGI_FORMAT format,
-    UINT sampleCount,
-    UINT sampleQuality,
-    D3D12_TEXTURE_LAYOUT layout,
-    D3D12_RESOURCE_FLAGS flags) {
+    static inline D3D12_RESOURCE_DESC Buffer(
+        UINT64 width,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        UINT64 alignment = 0) noexcept {
+        return ResourceDesc(
+            D3D12_RESOURCE_DIMENSION_BUFFER,
+            alignment,
+            width,
+            1,
+            1,
+            1,
+            DXGI_FORMAT_UNKNOWN,
+            1,
+            0,
+            D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
+            flags);
+    }
 
-    D3D12_RESOURCE_DESC desc = {};
-    desc.Dimension = dimension;
-    desc.Alignment = alignment;
-    desc.Width = width;
-    desc.Height = height;
-    desc.DepthOrArraySize = depthOrArraySize;
-    desc.MipLevels = mipLevels;
-    desc.Format = format;
-    desc.SampleDesc.Count = sampleCount;
-    desc.SampleDesc.Quality = sampleQuality;
-    desc.Layout = layout;
-    desc.Flags = flags;
-    return desc; 
-}
-
- static inline D3D12_RESOURCE_DESC Buffer(
-    UINT64 width,
-    D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
-    UINT64 alignment = 0) noexcept {
-    return ResourceDesc(
-        D3D12_RESOURCE_DIMENSION_BUFFER,
-        alignment,
-        width,
-        1,
-        1,
-        1,
-        DXGI_FORMAT_UNKNOWN,
-        1,
-        0,
-        D3D12_TEXTURE_LAYOUT_ROW_MAJOR,
-        flags);
-}
-
- static inline D3D12_RESOURCE_DESC Tex2D(
-    DXGI_FORMAT format,
-    UINT64 width,
-    UINT height,
-    UINT16 arraySize = 1,
-    UINT16 mipLevels = 0,
-    UINT sampleCount = 1,
-    UINT sampleQuality = 0,
-    D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
-    D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
-    UINT64 alignment = 0) noexcept {
-    return ResourceDesc(
-        D3D12_RESOURCE_DIMENSION_TEXTURE2D,
-        alignment,
-        width,
-        height,
-        arraySize,
-        mipLevels,
-        format,
-        sampleCount,
-        sampleQuality,
-        layout,
-        flags);
-}
+    static inline D3D12_RESOURCE_DESC Tex2D(
+        DXGI_FORMAT format,
+        UINT64 width,
+        UINT height,
+        UINT16 arraySize = 1,
+        UINT16 mipLevels = 0,
+        UINT sampleCount = 1,
+        UINT sampleQuality = 0,
+        D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+        D3D12_TEXTURE_LAYOUT layout = D3D12_TEXTURE_LAYOUT_UNKNOWN,
+        UINT64 alignment = 0) noexcept {
+        return ResourceDesc(
+            D3D12_RESOURCE_DIMENSION_TEXTURE2D,
+            alignment,
+            width,
+            height,
+            arraySize,
+            mipLevels,
+            format,
+            sampleCount,
+            sampleQuality,
+            layout,
+            flags);
+    }
 } // namespace ResourceDesc
 
-auto up::d3d12::TextureD3D12::create(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc, span<up::byte const> data)
-    -> bool {
+auto up::d3d12::TextureD3D12::create(
+    RenderContextD3D12 const& ctx,
+    GpuTextureDesc const& desc,
+    span<up::byte const> data) -> bool {
     if (desc.type == GpuTextureType::Texture2D) {
         return create2DTex(ctx, desc, data);
     }
@@ -100,18 +100,19 @@ auto up::d3d12::TextureD3D12::create(RenderContextD3D12 const& ctx, GpuTextureDe
         return createDepthStencilTex(ctx, desc);
     }
 
-     UP_UNREACHABLE("Unsupported texture type");
-    return false; 
+    UP_UNREACHABLE("Unsupported texture type");
+    return false;
 }
 
-auto up::d3d12::TextureD3D12::create2DTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc, span<up::byte const> data)
-        ->bool {
+auto up::d3d12::TextureD3D12::create2DTex(
+    RenderContextD3D12 const& ctx,
+    GpuTextureDesc const& desc,
+    span<up::byte const> data) -> bool {
     _format = toNative(desc.format);
     D3D12_RESOURCE_DESC resourceDesc = ResourceDesc::Tex2D(_format, desc.width, desc.height, 1, 1);
 
     D3D12MA::ALLOCATION_DESC allocDesc = {};
     allocDesc.HeapType = D3D12_HEAP_TYPE_DEFAULT;
-
 
     ctx.allocator()->CreateResource(
         &allocDesc,
@@ -129,8 +130,7 @@ auto up::d3d12::TextureD3D12::create2DTex(RenderContextD3D12 const& ctx, GpuText
     return true;
 }
 
-auto up::d3d12::TextureD3D12::createDepthStencilTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc)
-        ->bool {
+auto up::d3d12::TextureD3D12::createDepthStencilTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc) -> bool {
     _format = toNative(desc.format);
     D3D12_RESOURCE_DESC resourceDesc =
         ResourceDesc::Tex2D(_format, desc.width, desc.height, 1, 0, 1, 0, D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL);
@@ -155,23 +155,24 @@ auto up::d3d12::TextureD3D12::createDepthStencilTex(RenderContextD3D12 const& ct
     return true;
 }
 
-
-auto up::d3d12::TextureD3D12::uploadData(RenderContextD3D12 const& ctx, D3D12_RESOURCE_DESC& resourceDesc, span<up::byte const> data)
-    -> bool {
-
+auto up::d3d12::TextureD3D12::uploadData(
+    RenderContextD3D12 const& ctx,
+    D3D12_RESOURCE_DESC& resourceDesc,
+    span<up::byte const> data) -> bool {
     uint32 stride = static_cast<uint32>(resourceDesc.Width * toByteSize(fromNative(resourceDesc.Format)));
 
     UINT64 textureUploadBufferSize = 0;
-    static_cast<DeviceD3D12*>(ctx.device())->getDevice()->GetCopyableFootprints(
-        &resourceDesc,
-        0, // FirstSubresource
-        1, // NumSubresources
-        0, // BaseOffset
-        nullptr, // pLayouts
-        nullptr, // pNumRows
-        nullptr, // pRowSizeInBytes
-        &textureUploadBufferSize); // pTotalBytes
-
+    static_cast<DeviceD3D12*>(ctx.device())
+        ->getDevice()
+        ->GetCopyableFootprints(
+            &resourceDesc,
+            0, // FirstSubresource
+            1, // NumSubresources
+            0, // BaseOffset
+            nullptr, // pLayouts
+            nullptr, // pNumRows
+            nullptr, // pRowSizeInBytes
+            &textureUploadBufferSize); // pTotalBytes
 
     D3D12MA::ALLOCATION_DESC uploadAllocDesc = {};
     uploadAllocDesc.HeapType = D3D12_HEAP_TYPE_UPLOAD;

--- a/potato/librender/source/d3d12_backend/d3d12_texture.h
+++ b/potato/librender/source/d3d12_backend/d3d12_texture.h
@@ -1,0 +1,52 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_texture.h"
+#include "potato/runtime/com_ptr.h"
+#include "potato/spud/box.h"
+
+namespace up::d3d12 {
+    class RenderContextD3D12;
+    class DescriptorHeapD3D12;
+
+    class TextureD3D12 final : public GpuTexture {
+    public:
+        explicit TextureD3D12();
+        explicit TextureD3D12(ID3DResourcePtr buffer);
+        ~TextureD3D12() override = default;
+
+        TextureD3D12(TextureD3D12&&) = delete;
+        TextureD3D12& operator=(TextureD3D12&&) = delete;
+
+        bool create(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc, span<up::byte const> data);
+
+        GpuTextureType type() const noexcept override;
+        GpuFormat format() const noexcept override;
+        glm::ivec3 dimensions() const noexcept override;
+
+        DXGI_FORMAT nativeFormat() const noexcept;
+        ID3DResourceType* get() const { return _texture.get(); }
+
+        DescriptorHeapD3D12* desc() const { return _cbvHeap.get(); }
+
+    protected:
+        bool create2DTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc, span<up::byte const> data);
+        bool createDepthStencilTex(RenderContextD3D12 const& ctx, GpuTextureDesc const& desc);
+        bool uploadData(RenderContextD3D12 const& ctx, D3D12_RESOURCE_DESC& resourceDesc, span<up::byte const> data);
+
+    private:
+        ID3DResourcePtr _texture;
+        com_ptr<D3D12MA::Allocation> _allocation;
+
+        ID3DResourcePtr _uploadTexture;
+        com_ptr<D3D12MA::Allocation> _uploadAlloc;
+
+        // const buffer bits for now here while testing
+        box<DescriptorHeapD3D12> _cbvHeap;
+
+        DXGI_FORMAT _format;
+    };
+} // namespace up::d3d12

--- a/potato/librender/source/d3d12_backend/d3d12_utils.h
+++ b/potato/librender/source/d3d12_backend/d3d12_utils.h
@@ -1,0 +1,355 @@
+// Copyright by Potato Engine contributors. See accompanying License.txt for copyright details.
+
+#pragma once
+
+#include "d3d12_platform.h"
+
+#include "potato/render/gpu_common.h"
+
+#include <d3d12.h>
+
+namespace up::d3d12 {
+
+    //*********************************************************
+    //
+    // Copyright (c) Microsoft. All rights reserved.
+    // This code is licensed under the MIT License (MIT).
+    // THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF
+    // ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY
+    // IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR
+    // PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.
+    //
+    //*********************************************************
+
+    // Assign a name to the object to aid with debugging.
+#if defined(_DEBUG) || defined(DBG)
+    inline void SetName(ID3D12Object* pObject, LPCWSTR name) { pObject->SetName(name); }
+    inline void SetNameIndexed(ID3D12Object* pObject, LPCWSTR name, UINT index) {
+        WCHAR fullName[50];
+        if (swprintf_s(fullName, L"%s[%u]", name, index) > 0) {
+            pObject->SetName(fullName);
+        }
+    }
+#else
+    inline void SetName(ID3D12Object*, LPCWSTR) { }
+    inline void SetNameIndexed(ID3D12Object*, LPCWSTR, UINT) { }
+#endif
+
+    //------------------------------------------------------------------------------------------------
+    // Row-by-row memcpy
+    inline void MemcpySubresource(
+        _In_ const D3D12_MEMCPY_DEST* pDest,
+        _In_ const D3D12_SUBRESOURCE_DATA* pSrc,
+        SIZE_T RowSizeInBytes,
+        UINT NumRows,
+        UINT NumSlices) noexcept {
+        for (UINT z = 0; z < NumSlices; ++z) {
+            auto pDestSlice = static_cast<BYTE*>(pDest->pData) + pDest->SlicePitch * z;
+            auto pSrcSlice = static_cast<const BYTE*>(pSrc->pData) + pSrc->SlicePitch * LONG_PTR(z);
+            for (UINT y = 0; y < NumRows; ++y) {
+                memcpy(pDestSlice + pDest->RowPitch * y, pSrcSlice + pSrc->RowPitch * LONG_PTR(y), RowSizeInBytes);
+            }
+        }
+    }
+
+    //------------------------------------------------------------------------------------------------
+    // Returns required size of a buffer to be used for data upload
+    inline UINT64 GetRequiredIntermediateSize(
+        _In_ ID3D12Resource* pDestinationResource,
+        _In_range_(0, D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
+        _In_range_(0, D3D12_REQ_SUBRESOURCES - FirstSubresource) UINT NumSubresources) noexcept {
+        auto Desc = pDestinationResource->GetDesc();
+        UINT64 RequiredSize = 0;
+
+        ID3D12Device* pDevice = nullptr;
+        pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+        pDevice->GetCopyableFootprints(
+            &Desc,
+            FirstSubresource,
+            NumSubresources,
+            0,
+            nullptr,
+            nullptr,
+            nullptr,
+            &RequiredSize);
+        pDevice->Release();
+
+        return RequiredSize;
+    }
+
+    //------------------------------------------------------------------------------------------------
+    // All arrays must be populated (e.g. by calling GetCopyableFootprints)
+    inline UINT64 UpdateSubresources(
+        _In_ ID3D12GraphicsCommandList* pCmdList,
+        _In_ ID3D12Resource* pDestinationResource,
+        _In_ ID3D12Resource* pIntermediate,
+        _In_range_(0, D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
+        _In_range_(0, D3D12_REQ_SUBRESOURCES - FirstSubresource) UINT NumSubresources,
+        UINT64 RequiredSize,
+        _In_reads_(NumSubresources) const D3D12_PLACED_SUBRESOURCE_FOOTPRINT* pLayouts,
+        _In_reads_(NumSubresources) const UINT* pNumRows,
+        _In_reads_(NumSubresources) const UINT64* pRowSizesInBytes,
+        _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData) noexcept {
+        // Minor validation
+        auto IntermediateDesc = pIntermediate->GetDesc();
+        auto DestinationDesc = pDestinationResource->GetDesc();
+        if (IntermediateDesc.Dimension != D3D12_RESOURCE_DIMENSION_BUFFER ||
+            IntermediateDesc.Width < RequiredSize + pLayouts[0].Offset || RequiredSize > SIZE_T(-1) ||
+            (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER &&
+             (FirstSubresource != 0 || NumSubresources != 1))) {
+            return 0;
+        }
+
+        BYTE* pData;
+        HRESULT hr = pIntermediate->Map(0, nullptr, reinterpret_cast<void**>(&pData));
+        if (FAILED(hr)) {
+            return 0;
+        }
+
+        for (UINT i = 0; i < NumSubresources; ++i) {
+            if (pRowSizesInBytes[i] > SIZE_T(-1))
+                return 0;
+            D3D12_MEMCPY_DEST DestData = {
+                pData + pLayouts[i].Offset,
+                pLayouts[i].Footprint.RowPitch,
+                SIZE_T(pLayouts[i].Footprint.RowPitch) * SIZE_T(pNumRows[i])};
+            MemcpySubresource(
+                &DestData,
+                &pSrcData[i],
+                static_cast<SIZE_T>(pRowSizesInBytes[i]),
+                pNumRows[i],
+                pLayouts[i].Footprint.Depth);
+        }
+        pIntermediate->Unmap(0, nullptr);
+
+        if (DestinationDesc.Dimension == D3D12_RESOURCE_DIMENSION_BUFFER) {
+            pCmdList->CopyBufferRegion(
+                pDestinationResource,
+                0,
+                pIntermediate,
+                pLayouts[0].Offset,
+                pLayouts[0].Footprint.Width);
+        }
+        else {
+            for (UINT i = 0; i < NumSubresources; ++i) {
+                D3D12_TEXTURE_COPY_LOCATION Dst = {};
+                Dst.pResource = pDestinationResource;
+                Dst.Type = D3D12_TEXTURE_COPY_TYPE_SUBRESOURCE_INDEX;
+                Dst.PlacedFootprint = {};
+                Dst.SubresourceIndex = i + FirstSubresource;
+
+                D3D12_TEXTURE_COPY_LOCATION Src = {};
+                Src.pResource = pIntermediate;
+                Src.Type = D3D12_TEXTURE_COPY_TYPE_PLACED_FOOTPRINT;
+                Src.PlacedFootprint = pLayouts[i];
+
+                pCmdList->CopyTextureRegion(&Dst, 0, 0, 0, &Src, nullptr);
+            }
+        }
+        return RequiredSize;
+    }
+
+    //------------------------------------------------------------------------------------------------
+    // Heap-allocating UpdateSubresources implementation
+    inline UINT64 UpdateSubresources(
+        _In_ ID3D12Device* pDevice,
+        _In_ ID3D12GraphicsCommandList* pCmdList,
+        _In_ ID3D12Resource* pDestinationResource,
+        _In_ ID3D12Resource* pIntermediate,
+        UINT64 IntermediateOffset,
+        _In_range_(0, D3D12_REQ_SUBRESOURCES) UINT FirstSubresource,
+        _In_range_(0, D3D12_REQ_SUBRESOURCES - FirstSubresource) UINT NumSubresources,
+        _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData) noexcept {
+        UINT64 RequiredSize = 0;
+        UINT64 MemToAlloc =
+            static_cast<UINT64>(sizeof(D3D12_PLACED_SUBRESOURCE_FOOTPRINT) + sizeof(UINT) + sizeof(UINT64)) *
+            NumSubresources;
+        if (MemToAlloc > SIZE_MAX) {
+            return 0;
+        }
+        void* pMem = HeapAlloc(GetProcessHeap(), 0, static_cast<SIZE_T>(MemToAlloc));
+        if (pMem == nullptr) {
+            return 0;
+        }
+        auto pLayouts = static_cast<D3D12_PLACED_SUBRESOURCE_FOOTPRINT*>(pMem);
+        UINT64* pRowSizesInBytes = reinterpret_cast<UINT64*>(pLayouts + NumSubresources);
+        UINT* pNumRows = reinterpret_cast<UINT*>(pRowSizesInBytes + NumSubresources);
+
+        auto Desc = pDestinationResource->GetDesc();
+        pDevice->GetCopyableFootprints(
+            &Desc,
+            FirstSubresource,
+            NumSubresources,
+            IntermediateOffset,
+            pLayouts,
+            pNumRows,
+            pRowSizesInBytes,
+            &RequiredSize);
+
+        UINT64 Result = UpdateSubresources(
+            pCmdList,
+            pDestinationResource,
+            pIntermediate,
+            FirstSubresource,
+            NumSubresources,
+            RequiredSize,
+            pLayouts,
+            pNumRows,
+            pRowSizesInBytes,
+            pSrcData);
+        HeapFree(GetProcessHeap(), 0, pMem);
+        return Result;
+    }
+
+    //------------------------------------------------------------------------------------------------
+    // Stack-allocating UpdateSubresources implementation
+    template <UINT MaxSubresources>
+    inline UINT64 UpdateSubresources(
+        _In_ ID3D12GraphicsCommandList* pCmdList,
+        _In_ ID3D12Resource* pDestinationResource,
+        _In_ ID3D12Resource* pIntermediate,
+        UINT64 IntermediateOffset,
+        _In_range_(0, MaxSubresources) UINT FirstSubresource,
+        _In_range_(1, MaxSubresources - FirstSubresource) UINT NumSubresources,
+        _In_reads_(NumSubresources) const D3D12_SUBRESOURCE_DATA* pSrcData) noexcept {
+        UINT64 RequiredSize = 0;
+        D3D12_PLACED_SUBRESOURCE_FOOTPRINT Layouts[MaxSubresources];
+        UINT NumRows[MaxSubresources];
+        UINT64 RowSizesInBytes[MaxSubresources];
+
+        auto Desc = pDestinationResource->GetDesc();
+        ID3D12Device* pDevice = nullptr;
+        pDestinationResource->GetDevice(IID_ID3D12Device, reinterpret_cast<void**>(&pDevice));
+        pDevice->GetCopyableFootprints(
+            &Desc,
+            FirstSubresource,
+            NumSubresources,
+            IntermediateOffset,
+            Layouts,
+            NumRows,
+            RowSizesInBytes,
+            &RequiredSize);
+        pDevice->Release();
+
+        return UpdateSubresources(
+            pCmdList,
+            pDestinationResource,
+            pIntermediate,
+            FirstSubresource,
+            NumSubresources,
+            RequiredSize,
+            Layouts,
+            NumRows,
+            RowSizesInBytes,
+            pSrcData);
+    }
+
+    // collection of common descriptors used in DX12
+    class Desc {
+    public:
+        class Buffer : public D3D12_RESOURCE_DESC {
+        public:
+            Buffer(uint32 size, D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE, uint32 alignment = 0) noexcept {
+                Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE3D;
+                Alignment = alignment;
+                Width = size;
+                Height = 1;
+                DepthOrArraySize = 1;
+                MipLevels = 1;
+                Format = DXGI_FORMAT_UNKNOWN;
+                SampleDesc.Count = 1;
+                SampleDesc.Quality = 0;
+                Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+                Flags = flags;
+            }
+        };
+
+        class Tex1D : public D3D12_RESOURCE_DESC {
+        public:
+            Tex1D(
+                DXGI_FORMAT format,
+                uint32 width,
+                uint32 arraySize = 1,
+                uint16 mipLevels = 0,
+                D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+                uint32 alignment = 0) noexcept {
+                Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE3D;
+                Alignment = alignment;
+                Width = width;
+                Height = 1;
+                DepthOrArraySize = 1;
+                MipLevels = mipLevels;
+                Format = format;
+                SampleDesc.Count = 1;
+                SampleDesc.Quality = 0;
+                Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+                Flags = flags;
+            }
+        };
+
+        class Tex2D : public D3D12_RESOURCE_DESC {
+        public:
+            Tex2D(
+                DXGI_FORMAT format,
+                uint32 width,
+                uint32 height,
+                uint16 arraySize = 1,
+                uint16 mipLevels = 0,
+                uint sampleCount = 1,
+                uint sampleQuality = 0,
+                D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+                uint32 alignment = 0) noexcept {
+                Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE3D;
+                Alignment = alignment;
+                Width = width;
+                Height = height;
+                DepthOrArraySize = 1;
+                MipLevels = mipLevels;
+                Format = format;
+                SampleDesc.Count = sampleCount;
+                SampleDesc.Quality = sampleQuality;
+                Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+                Flags = flags;
+            }
+        };
+
+        class Tex3D : public D3D12_RESOURCE_DESC {
+        public:
+            Tex3D(
+                DXGI_FORMAT format,
+                uint32 width,
+                uint32 height,
+                uint32 depth,
+                uint16 mipLevels = 0,
+                D3D12_RESOURCE_FLAGS flags = D3D12_RESOURCE_FLAG_NONE,
+                uint32 alignment = 0) noexcept {
+                Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE3D;
+                Alignment = alignment;
+                Width = width;
+                Height = height;
+                DepthOrArraySize = depth;
+                MipLevels = mipLevels;
+                Format = format;
+                SampleDesc.Count = 1;
+                SampleDesc.Quality = 0;
+                Layout = D3D12_TEXTURE_LAYOUT_ROW_MAJOR;
+                Flags = flags;
+            }
+        };
+    };
+
+    class Heap {
+    public:
+        class Basic : public D3D12_HEAP_PROPERTIES {
+        public:
+            Basic(D3D12_HEAP_TYPE type, UINT creationNodeMask = 1, UINT nodeMask = 1) noexcept {
+                Type = type;
+                CPUPageProperty = D3D12_CPU_PAGE_PROPERTY_UNKNOWN;
+                MemoryPoolPreference = D3D12_MEMORY_POOL_UNKNOWN;
+                CreationNodeMask = creationNodeMask;
+                VisibleNodeMask = nodeMask;
+            }
+        };
+    };
+
+} // namespace up::d3d12


### PR DESCRIPTION
This import's Marcin's D3D12 backend, but without the accompanying changes in the rest of Potato.

It adds it as a flag behind `UP_BUILD_D3D12` (which can be set in `CMakeUserPresets.json` or by modifying the CMake cache directly, etc.)

It won't build as-is, as it will need to be updated for the many changes in main since the DX12 code was last fully merged.

The main purpose is to get the code in main so we can iterate on it together and not keep Marcin or DX12 banished to a separate branch that's nearly impossible to keep up-to-date.

My instinct is that we should continue refactoring the primary Potato rendering infrastructure until it's easier to fully finish/enable this backend without requiring extensive backend-specific changes or hacks throughout the rest of the codebase.

