### PR TITLE
Rework and expand samplers

### DIFF
--- a/potato/librender/data/shaders/imgui.hlsl
+++ b/potato/librender/data/shaders/imgui.hlsl
@@ -1,8 +1,8 @@
 cbuffer vertexBuffer : register(b0) {
     float4x4 ProjectionMatrix;
 };
-SamplerState sampler0: register(s0);
-Texture2D texture0: register(t0);
+SamplerState linearSampler : register(s0);
+Texture2D texture0 : register(t0);
 
 struct VS_Input {
     float2 pos : POSITION;
@@ -31,6 +31,6 @@ struct PS_INPUT {
 };
 
 float4 pixel_main(VS_Output input) : SV_Target{
-    float4 out_col = input.col * texture0.Sample(sampler0, input.uv);
+    float4 out_col = input.col * texture0.Sample(linearSampler, input.uv);
     return out_col;
 };

--- a/potato/librender/data/shaders/imgui.hlsl
+++ b/potato/librender/data/shaders/imgui.hlsl
@@ -1,7 +1,7 @@
 cbuffer vertexBuffer : register(b0) {
     float4x4 ProjectionMatrix;
 };
-SamplerState linearSampler : register(s0);
+SamplerState bilinearSampler : register(s1);
 Texture2D texture0 : register(t0);
 
 struct VS_Input {
@@ -31,6 +31,6 @@ struct PS_INPUT {
 };
 
 float4 pixel_main(VS_Output input) : SV_Target{
-    float4 out_col = input.col * texture0.Sample(linearSampler, input.uv);
+    float4 out_col = input.col * texture0.Sample(bilinearSampler, input.uv);
     return out_col;
 };

--- a/potato/librender/include/potato/render/gpu_common.h
+++ b/potato/librender/include/potato/render/gpu_common.h
@@ -52,11 +52,13 @@ namespace up {
         Lines,
     };
 
-    enum class GpuBindType {
-        Constant,
-        UnorderedAccess,
-        Texture,
-        Sampler,
+    enum class GpuTextureAddressMode { Wrap, Clamp };
+
+    enum class GpuFilter {
+        MinMagMip_Point,
+        MinMag_Point_Mip_Linear,
+        MinMagMip_Linear,
+        Anisotropic
     };
 
     struct GpuClipRect {
@@ -82,6 +84,11 @@ namespace up {
         GpuFormat format = GpuFormat::Unknown;
         GpuTextureType type = GpuTextureType::DepthStencil;
         uint32 width = 0, height = 0;
+    };
+
+    struct GpuSamplerDesc {
+        GpuTextureAddressMode address = GpuTextureAddressMode::Clamp; // separate uvw? uses?
+        GpuFilter filter = GpuFilter::MinMagMip_Linear;
     };
 
     struct GpuDataDesc {

--- a/potato/librender/include/potato/render/gpu_common.h
+++ b/potato/librender/include/potato/render/gpu_common.h
@@ -57,6 +57,7 @@ namespace up {
     enum class GpuFilter {
         MinMagMip_Point,
         MinMag_Point_Mip_Linear,
+        MinMag_Linear_Mip_Point,
         MinMagMip_Linear,
         Anisotropic
     };

--- a/potato/librender/include/potato/render/gpu_device.h
+++ b/potato/librender/include/potato/render/gpu_device.h
@@ -39,7 +39,7 @@ namespace up {
         virtual rc<GpuPipelineState> createPipelineState(GpuPipelineStateDesc const& desc) = 0;
         virtual rc<GpuResource> createBuffer(GpuBufferDesc const& desc, GpuDataDesc const& data = {}) = 0;
         virtual rc<GpuResource> createTexture2D(GpuTextureDesc const& desc, GpuDataDesc const& data = {}) = 0;
-        virtual rc<GpuSampler> createSampler() = 0;
+        virtual rc<GpuSampler> createSampler(GpuSamplerDesc const& desc) = 0;
 
         virtual void execute(GpuCommandList* commandList) = 0;
 

--- a/potato/librender/include/potato/render/material.h
+++ b/potato/librender/include/potato/render/material.h
@@ -16,7 +16,6 @@ namespace up {
     class CommandList;
     class GpuDevice;
     class GpuPipelineState;
-    class GpuResourceView;
     class GpuSampler;
     class RenderContext;
 
@@ -27,9 +26,7 @@ namespace up {
         UP_RENDER_API explicit Material(
             AssetKey key,
             rc<GpuPipelineState> pipelineState,
-            vector<Texture::Handle> textures,
-            vector<box<GpuResourceView>> srvs,
-            vector<rc<GpuSampler>> samplers);
+            vector<Texture::Handle> textures);
         UP_RENDER_API ~Material();
 
         static UP_RENDER_API auto createFromBuffer(
@@ -45,7 +42,5 @@ namespace up {
     private:
         rc<GpuPipelineState> _pipelineState;
         vector<Texture::Handle> _textures;
-        vector<box<GpuResourceView>> _srvs;
-        vector<rc<GpuSampler>> _samplers;
     };
 } // namespace up

--- a/potato/librender/include/potato/render/renderer.h
+++ b/potato/librender/include/potato/render/renderer.h
@@ -14,6 +14,7 @@ namespace up {
     class GpuCommandList;
     class GpuPipelineState;
     class GpuDevice;
+    class GpuSampler;
     class RenderContext;
     class AssetLoader;
 
@@ -38,6 +39,7 @@ namespace up {
     private:
         rc<GpuDevice> _device;
         rc<GpuResource> _frameDataBuffer;
+        rc<GpuSampler> _linearSampler;
         uint32 _frameCounter = 0;
         uint64 _startTimestamp = 0;
         double _frameTimestamp = 0;

--- a/potato/librender/include/potato/render/renderer.h
+++ b/potato/librender/include/potato/render/renderer.h
@@ -40,6 +40,7 @@ namespace up {
         rc<GpuDevice> _device;
         rc<GpuResource> _frameDataBuffer;
         rc<GpuSampler> _linearSampler;
+        rc<GpuSampler> _bilinearSampler;
         uint32 _frameCounter = 0;
         uint64 _startTimestamp = 0;
         double _frameTimestamp = 0;

--- a/potato/librender/include/potato/render/texture.h
+++ b/potato/librender/include/potato/render/texture.h
@@ -5,25 +5,29 @@
 #include "_export.h"
 
 #include "potato/runtime/asset.h"
+#include "potato/spud/box.h"
 #include "potato/spud/rc.h"
 
 namespace up {
     class AssetLoader;
     class GpuDevice;
     class GpuResource;
+    class GpuResourceView;
 
     class Texture : public AssetBase<Texture> {
     public:
         static constexpr zstring_view assetTypeName = "potato.asset.texture"_zsv;
 
-        UP_RENDER_API explicit Texture(AssetKey key, rc<GpuResource> texture);
+        UP_RENDER_API explicit Texture(AssetKey key, rc<GpuResource> texture, box<GpuResourceView> srv);
         UP_RENDER_API ~Texture();
 
         GpuResource& texture() const noexcept { return *_texture; }
+        GpuResourceView& srv() const noexcept { return *_srv; }
 
         static UP_RENDER_API void registerLoader(AssetLoader& assetLoader, GpuDevice& device);
 
     private:
         rc<GpuResource> _texture;
+        box<GpuResourceView> _srv;
     };
 } // namespace up

--- a/potato/librender/source/d3d11_backend/d3d11_device.cpp
+++ b/potato/librender/source/d3d11_backend/d3d11_device.cpp
@@ -276,13 +276,13 @@ namespace up::d3d11 {
 
     auto DeviceD3D11::createSampler(GpuSamplerDesc const& desc) -> rc<GpuSampler> {
         D3D11_SAMPLER_DESC nativeDesc = {};
-        nativeDesc.AddressU = D3D11_TEXTURE_ADDRESS_WRAP;
-        nativeDesc.AddressV = D3D11_TEXTURE_ADDRESS_WRAP;
-        nativeDesc.AddressW = D3D11_TEXTURE_ADDRESS_WRAP;
+        nativeDesc.AddressU = toNative(desc.address);
+        nativeDesc.AddressV = nativeDesc.AddressU;
+        nativeDesc.AddressW = nativeDesc.AddressU;
         nativeDesc.ComparisonFunc = D3D11_COMPARISON_ALWAYS;
-        nativeDesc.Filter = D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        nativeDesc.Filter = toNative(desc.filter);
         nativeDesc.MaxAnisotropy = 1;
-        nativeDesc.MaxLOD = 0;
+        nativeDesc.MaxLOD = 9999;
         nativeDesc.MinLOD = 0;
 
         com_ptr<ID3D11SamplerState> sampler;

--- a/potato/librender/source/d3d11_backend/d3d11_device.h
+++ b/potato/librender/source/d3d11_backend/d3d11_device.h
@@ -31,7 +31,7 @@ namespace up::d3d11 {
         rc<GpuPipelineState> createPipelineState(GpuPipelineStateDesc const& desc) override;
         rc<GpuResource> createBuffer(GpuBufferDesc const& desc, GpuDataDesc const& data) override;
         rc<GpuResource> createTexture2D(GpuTextureDesc const& desc, GpuDataDesc const& data) override;
-        rc<GpuSampler> createSampler() override;
+        rc<GpuSampler> createSampler(GpuSamplerDesc const& desc) override;
 
         void execute(GpuCommandList* commandList) override;
 
@@ -44,10 +44,13 @@ namespace up::d3d11 {
         void renderDebugDraw(GpuCommandList& commandList) override;
 
     private:
+        bool _createSamplers();
+
         com_ptr<IDXGIFactory2> _factory;
         com_ptr<IDXGIAdapter1> _adaptor;
         com_ptr<ID3D11Device> _device;
         com_ptr<ID3D11DeviceContext> _context;
+        com_ptr<ID3D11SamplerState> _linearSampler; // FIXME: this should be managed by the Renderer, not Device
         box<DebugDrawRendererD3D11> _debugDrawer;
         box<ImguiRendererD3D11> _imguiBackend;
     };

--- a/potato/librender/source/d3d11_backend/d3d11_device.h
+++ b/potato/librender/source/d3d11_backend/d3d11_device.h
@@ -44,13 +44,10 @@ namespace up::d3d11 {
         void renderDebugDraw(GpuCommandList& commandList) override;
 
     private:
-        bool _createSamplers();
-
         com_ptr<IDXGIFactory2> _factory;
         com_ptr<IDXGIAdapter1> _adaptor;
         com_ptr<ID3D11Device> _device;
         com_ptr<ID3D11DeviceContext> _context;
-        com_ptr<ID3D11SamplerState> _linearSampler; // FIXME: this should be managed by the Renderer, not Device
         box<DebugDrawRendererD3D11> _debugDrawer;
         box<ImguiRendererD3D11> _imguiBackend;
     };

--- a/potato/librender/source/d3d11_backend/d3d11_imgui_renderer.cpp
+++ b/potato/librender/source/d3d11_backend/d3d11_imgui_renderer.cpp
@@ -167,9 +167,13 @@ namespace up::d3d11 {
         texData.pitch = fontWidth * 4;
         texData.data = span{pixels, static_cast<uint32>(fontHeight * texData.pitch)}.as_bytes();
 
+        GpuSamplerDesc samplerDesc;
+        samplerDesc.address = GpuTextureAddressMode::Clamp;
+        samplerDesc.filter = GpuFilter::MinMag_Point_Mip_Linear;
+
         auto font = _device.createTexture2D(texDesc, texData);
         _srv = _device.createShaderResourceView(font.get());
 
-        _sampler = _device.createSampler();
+        _sampler = _device.createSampler(samplerDesc);
     }
 } // namespace up::d3d11

--- a/potato/librender/source/d3d11_backend/d3d11_platform.cpp
+++ b/potato/librender/source/d3d11_backend/d3d11_platform.cpp
@@ -44,6 +44,34 @@ auto up::d3d11::toNative(GpuFormat format) noexcept -> DXGI_FORMAT {
     }
 }
 
+auto up::d3d11::toNative(GpuTextureAddressMode address) noexcept -> D3D11_TEXTURE_ADDRESS_MODE {
+    switch (address) {
+        case GpuTextureAddressMode::Clamp:
+            return D3D11_TEXTURE_ADDRESS_CLAMP;
+        case GpuTextureAddressMode::Wrap:
+            return D3D11_TEXTURE_ADDRESS_WRAP;
+        default:
+            UP_UNREACHABLE("Unknown texture address mode");
+            return D3D11_TEXTURE_ADDRESS_CLAMP;
+    }
+}
+
+auto up::d3d11::toNative(GpuFilter filter) noexcept -> D3D11_FILTER {
+    switch (filter) {
+        case GpuFilter::MinMagMip_Point:
+            return D3D11_FILTER_MIN_MAG_MIP_POINT;
+        case GpuFilter::MinMagMip_Linear:
+            return D3D11_FILTER_MIN_MAG_MIP_LINEAR;
+        case GpuFilter::MinMag_Point_Mip_Linear:
+            return D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR;
+        case GpuFilter::Anisotropic:
+            return D3D11_FILTER_ANISOTROPIC;
+        default:
+            UP_UNREACHABLE("Unknown filter");
+            return D3D11_FILTER_MIN_MAG_MIP_POINT;
+    }
+}
+
 auto up::d3d11::fromNative(DXGI_FORMAT format) noexcept -> GpuFormat {
     switch (format) {
         case DXGI_FORMAT_R32G32B32A32_FLOAT:

--- a/potato/librender/source/d3d11_backend/d3d11_platform.cpp
+++ b/potato/librender/source/d3d11_backend/d3d11_platform.cpp
@@ -64,6 +64,8 @@ auto up::d3d11::toNative(GpuFilter filter) noexcept -> D3D11_FILTER {
             return D3D11_FILTER_MIN_MAG_MIP_LINEAR;
         case GpuFilter::MinMag_Point_Mip_Linear:
             return D3D11_FILTER_MIN_MAG_POINT_MIP_LINEAR;
+        case GpuFilter::MinMag_Linear_Mip_Point:
+            return D3D11_FILTER_MIN_MAG_LINEAR_MIP_POINT;
         case GpuFilter::Anisotropic:
             return D3D11_FILTER_ANISOTROPIC;
         default:

--- a/potato/librender/source/d3d11_backend/d3d11_platform.h
+++ b/potato/librender/source/d3d11_backend/d3d11_platform.h
@@ -12,6 +12,8 @@
 namespace up::d3d11 {
     extern zstring_view toNative(GpuShaderSemantic semantic) noexcept;
     extern DXGI_FORMAT toNative(GpuFormat format) noexcept;
+    extern D3D11_TEXTURE_ADDRESS_MODE toNative(GpuTextureAddressMode address) noexcept;
+    extern D3D11_FILTER toNative(GpuFilter filter) noexcept;
     extern GpuFormat fromNative(DXGI_FORMAT format) noexcept;
     extern uint32 toByteSize(GpuFormat format) noexcept;
     extern DXGI_FORMAT toNative(GpuIndexFormat type) noexcept;

--- a/potato/librender/source/null_backend/null_objects.cpp
+++ b/potato/librender/source/null_backend/null_objects.cpp
@@ -42,7 +42,7 @@ namespace up::null {
         return new_shared<TextureNull>();
     }
 
-    auto DeviceNull::createSampler() -> rc<GpuSampler> { return new_shared<SamplerNull>(); }
+    auto DeviceNull::createSampler(GpuSamplerDesc const& desc) -> rc<GpuSampler> { return new_shared<SamplerNull>(); }
 
     void DeviceNull::beginImguiFrame(ImGuiContext&) { }
 

--- a/potato/librender/source/null_backend/null_objects.h
+++ b/potato/librender/source/null_backend/null_objects.h
@@ -29,7 +29,7 @@ namespace up::null {
         rc<GpuPipelineState> createPipelineState(GpuPipelineStateDesc const& desc) override;
         rc<GpuResource> createBuffer(GpuBufferDesc const& desc, GpuDataDesc const& data) override;
         rc<GpuResource> createTexture2D(GpuTextureDesc const& desc, GpuDataDesc const& data) override;
-        rc<GpuSampler> createSampler() override;
+        rc<GpuSampler> createSampler(GpuSamplerDesc const& desc) override;
 
         box<GpuResourceView> createRenderTargetView(GpuResource* renderTarget) override;
         box<GpuResourceView> createDepthStencilView(GpuResource* depthStencilBuffer) override;

--- a/potato/librender/source/renderer.cpp
+++ b/potato/librender/source/renderer.cpp
@@ -8,6 +8,7 @@
 #include "potato/render/gpu_device.h"
 #include "potato/render/gpu_pipeline_state.h"
 #include "potato/render/gpu_resource.h"
+#include "potato/render/gpu_sampler.h"
 #include "potato/render/gpu_swap_chain.h"
 #include "potato/render/material.h"
 #include "potato/render/mesh.h"
@@ -43,6 +44,11 @@ void up::Renderer::beginFrame() {
         _startTimestamp = nowNanoseconds;
     }
 
+    if (_linearSampler == nullptr) {
+        _linearSampler = _device->createSampler(
+            {.address = GpuTextureAddressMode::Clamp, .filter = GpuFilter::MinMag_Point_Mip_Linear});
+    }
+
     double const now = static_cast<double>(nowNanoseconds - _startTimestamp) * nanoToSeconds;
     _frameTimestep = static_cast<float>(now - _frameTimestamp);
     _frameTimestamp = now;
@@ -62,6 +68,7 @@ auto up::Renderer::createCommandList() const noexcept -> rc<GpuCommandList> {
     commandList->begin();
     commandList->update(_frameDataBuffer.get(), view<byte>{reinterpret_cast<byte*>(&frame), sizeof(frame)});
     commandList->bindConstantBuffer(0, _frameDataBuffer.get(), GpuShaderStage::All);
+    commandList->bindSampler(0, _linearSampler.get(), GpuShaderStage::All);
 
     return commandList;
 }

--- a/potato/librender/source/renderer.cpp
+++ b/potato/librender/source/renderer.cpp
@@ -45,8 +45,12 @@ void up::Renderer::beginFrame() {
     }
 
     if (_linearSampler == nullptr) {
-        _linearSampler = _device->createSampler(
-            {.address = GpuTextureAddressMode::Clamp, .filter = GpuFilter::MinMag_Point_Mip_Linear});
+        _linearSampler =
+            _device->createSampler({.address = GpuTextureAddressMode::Clamp, .filter = GpuFilter::MinMagMip_Point});
+    }
+    if (_bilinearSampler == nullptr) {
+        _bilinearSampler = _device->createSampler(
+            {.address = GpuTextureAddressMode::Clamp, .filter = GpuFilter::MinMag_Linear_Mip_Point});
     }
 
     double const now = static_cast<double>(nowNanoseconds - _startTimestamp) * nanoToSeconds;
@@ -69,6 +73,7 @@ auto up::Renderer::createCommandList() const noexcept -> rc<GpuCommandList> {
     commandList->update(_frameDataBuffer.get(), view<byte>{reinterpret_cast<byte*>(&frame), sizeof(frame)});
     commandList->bindConstantBuffer(0, _frameDataBuffer.get(), GpuShaderStage::All);
     commandList->bindSampler(0, _linearSampler.get(), GpuShaderStage::All);
+    commandList->bindSampler(1, _bilinearSampler.get(), GpuShaderStage::All);
 
     return commandList;
 }

--- a/potato/librender/source/texture.cpp
+++ b/potato/librender/source/texture.cpp
@@ -4,6 +4,7 @@
 
 #include "potato/render/gpu_device.h"
 #include "potato/render/gpu_resource.h"
+#include "potato/render/gpu_resource_view.h"
 #include "potato/runtime/asset_loader.h"
 #include "potato/runtime/stream.h"
 #include "potato/spud/unique_resource.h"
@@ -79,7 +80,12 @@ namespace up {
                     return nullptr;
                 }
 
-                return new_shared<Texture>(ctx.key, std::move(tex));
+                auto srv = _device.createShaderResourceView(tex.get());
+                if (srv == nullptr) {
+                    return nullptr;
+                }
+
+                return new_shared<Texture>(ctx.key, std::move(tex), std::move(srv));
             }
 
         private:
@@ -87,9 +93,10 @@ namespace up {
         };
     } // namespace
 
-    Texture::Texture(AssetKey key, rc<GpuResource> texture)
+    Texture::Texture(AssetKey key, rc<GpuResource> texture, box<GpuResourceView> srv)
         : AssetBase(std::move(key))
-        , _texture(std::move(texture)) { }
+        , _texture(std::move(texture))
+        , _srv(std::move(srv)) { }
 
     Texture::~Texture() = default;
 

--- a/resources/shaders/basic.hlsl
+++ b/resources/shaders/basic.hlsl
@@ -6,8 +6,8 @@ struct VS_Input {
     float2 uv : TEXCOORD0;
 };
 
-sampler sampler0;
-Texture2D texture0;
+sampler linearSampler : register(s0);
+Texture2D texture0 : register(t0);
 
 struct VS_Output {
     float4 position : SV_Position;

--- a/resources/shaders/basic.hlsl
+++ b/resources/shaders/basic.hlsl
@@ -6,7 +6,7 @@ struct VS_Input {
     float2 uv : TEXCOORD0;
 };
 
-sampler linearSampler : register(s0);
+SamplerState bilinearSampler : register(s1);
 Texture2D texture0 : register(t0);
 
 struct VS_Output {
@@ -27,5 +27,5 @@ VS_Output vertex_main(VS_Input input) {
 }
 
 float4 pixel_main(VS_Output input) : SV_Target {
-    return float4(texture0.Sample(sampler0, input.uv).rgb, 1);
+    return float4(texture0.Sample(bilinearSampler, input.uv).rgb, 1);
 }

--- a/resources/shaders/full.hlsl
+++ b/resources/shaders/full.hlsl
@@ -8,7 +8,7 @@ struct VS_Input {
     float2 uv : TEXCOORD0;
 };
 
-sampler linearSampler : register(s0);
+SamplerState bilinearSampler : register(s1);
 Texture2D texture0 : register(t0);
 Texture2D texture1 : register(t1);
 Texture2D texture2 : register(t2);
@@ -41,7 +41,7 @@ VS_Output vertex_main(VS_Input input) {
 
 float4 pixel_main(VS_Output input) : SV_Target {
     // Normal map
-    float3 mappedNormal = texture1.Sample(linearSampler, input.uv).xyz * 2 - 1;
+    float3 mappedNormal = texture1.Sample(bilinearSampler, input.uv).xyz * 2 - 1;
     mappedNormal = mul(mappedNormal, input.tangentSpace);
     mappedNormal = normalize(mappedNormal);
 
@@ -49,10 +49,10 @@ float4 pixel_main(VS_Output input) : SV_Target {
     float3 blendedNormal = normalize(float3(mappedNormal.xy + normal.xy, mappedNormal.z*normal.z));
 
     // AO
-    float3 shadow = texture2.Sample(linearSampler, input.uv).rgb;
+    float3 shadow = texture2.Sample(bilinearSampler, input.uv).rgb;
 
     // Diffuse
-    float3 color = texture0.Sample(linearSampler, input.uv).rgb;
+    float3 color = texture0.Sample(bilinearSampler, input.uv).rgb;
 
     // Calculate lighting
     float light = max(0, dot(blendedNormal, float3(0, 1, 1)));

--- a/resources/shaders/full.hlsl
+++ b/resources/shaders/full.hlsl
@@ -8,11 +8,9 @@ struct VS_Input {
     float2 uv : TEXCOORD0;
 };
 
-sampler sampler0 : register(s0);
+sampler linearSampler : register(s0);
 Texture2D texture0 : register(t0);
-sampler sampler1 : register(s1);
 Texture2D texture1 : register(t1);
-sampler sampler2 : register(s2);
 Texture2D texture2 : register(t2);
 
 struct VS_Output {
@@ -43,7 +41,7 @@ VS_Output vertex_main(VS_Input input) {
 
 float4 pixel_main(VS_Output input) : SV_Target {
     // Normal map
-    float3 mappedNormal = texture1.Sample(sampler1, input.uv).xyz * 2 - 1;
+    float3 mappedNormal = texture1.Sample(linearSampler, input.uv).xyz * 2 - 1;
     mappedNormal = mul(mappedNormal, input.tangentSpace);
     mappedNormal = normalize(mappedNormal);
 
@@ -51,10 +49,10 @@ float4 pixel_main(VS_Output input) : SV_Target {
     float3 blendedNormal = normalize(float3(mappedNormal.xy + normal.xy, mappedNormal.z*normal.z));
 
     // AO
-    float3 shadow = texture2.Sample(sampler2, input.uv).rgb;
+    float3 shadow = texture2.Sample(linearSampler, input.uv).rgb;
 
     // Diffuse
-    float3 color = texture0.Sample(sampler0, input.uv).rgb;
+    float3 color = texture0.Sample(linearSampler, input.uv).rgb;
 
     // Calculate lighting
     float light = max(0, dot(blendedNormal, float3(0, 1, 1)));


### PR DESCRIPTION
- Materials no longer create or bind a bunch of samplers
- Default samplers (linear and bilinear so far) are bound for all shaders
- Will probably need to be expanded eventually; simpler for now, will simplify D3D12 migration (I think)