### PR TITLE
Asset Browser cleanups

### DIFF
--- a/potato/bin_shell/source/editors/asset_browser.cpp
+++ b/potato/bin_shell/source/editors/asset_browser.cpp
@@ -239,12 +239,13 @@ void up::shell::AssetBrowser::_showBreadcrumb(int index) {
 void up::shell::AssetBrowser::_showBreadcrumbs() {
     ImGuiWindow* const window = ImGui::GetCurrentWindow();
     ImDrawList* const drawList = window->DrawList;
+    ImGuiStyle const& style = ImGui::GetStyle();
 
     drawList->AddRectFilled(
         window->DC.CursorPos,
         window->DC.CursorPos +
             ImVec2{
-                ImGui::GetContentRegionAvail().x,
+                ImGui::GetContentRegionAvail().x - style.FramePadding.x,
                 ImGui::GetTextLineHeightWithSpacing() + ImGui::GetItemSpacing().y * 3},
         ImGui::GetColorU32(ImGuiCol_Header),
         4.f);

--- a/potato/bin_shell/source/editors/asset_browser.cpp
+++ b/potato/bin_shell/source/editors/asset_browser.cpp
@@ -457,7 +457,7 @@ void up::shell::AssetBrowser::_rebuild() {
     }
 
     for (ResourceManifest::Record const& record : manifest->records()) {
-        auto const lastSepIndex = record.filename.find_last_of("/"_sv);
+        auto const lastSepIndex = record.filename.find_last_of("\\/"_sv);
         auto const start = lastSepIndex != string::npos ? lastSepIndex + 1 : 0;
 
         if (record.logicalId != ResourceManifest::Id{}) {

--- a/potato/bin_shell/source/editors/asset_browser.h
+++ b/potato/bin_shell/source/editors/asset_browser.h
@@ -60,6 +60,8 @@ namespace up::shell {
             string name;
             uint64 typeHash = 0;
             size_t size = 0;
+            uint32 childFileCount = 0;
+            uint32 childFolderCount = 0;
             int firstChild = -1;
             int nextSibling = -1;
             int parentIndex = -1;

--- a/potato/libeditor/include/potato/editor/imgui_ext.h
+++ b/potato/libeditor/include/potato/editor/imgui_ext.h
@@ -16,6 +16,12 @@ namespace ImGui::inline Potato {
         char const* icon,
         ImVec2 size = {},
         ImGuiButtonFlags flags = ImGuiButtonFlags_None);
+    UP_EDITOR_API bool BeginIconButtonDropdown(
+        char const* label,
+        char const* icon,
+        ImVec2 size = {},
+        ImGuiButtonFlags flags = ImGuiButtonFlags_None);
+    UP_EDITOR_API void EndIconButtonDropdown();
 
     UP_EDITOR_API bool IsModifierDown(ImGuiKeyModFlags modifiers) noexcept;
 

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -110,6 +110,18 @@ bool ImGui::Potato::IconButton(char const* label, char const* icon, ImVec2 size,
     return pressed;
 }
 
+bool ImGui::Potato::BeginIconButtonDropdown(char const* label, char const* icon, ImVec2 size, ImGuiButtonFlags flags) {
+    if (IconButton(label, icon, size, flags)) {
+        ImGui::OpenPopup(label);
+    }
+
+    return ImGui::BeginPopup(label);
+}
+
+void ImGui::Potato::EndIconButtonDropdown() {
+    ImGui::EndPopup();
+}
+
 bool ImGui::Potato::IsModifierDown(ImGuiKeyModFlags modifiers) noexcept {
     auto& io = ImGui::GetIO();
     return (io.KeyMods & modifiers) == modifiers;
@@ -158,7 +170,8 @@ ImVec2 ImGui::Potato::GetItemInnerSpacing() {
 
 bool ImGui::Potato::BeginIconGrid(char const* label, float iconWidth) {
     ImGuiStyle const& style = GetStyle();
-    float const availWidth = std::max(ImGui::GetContentRegionAvailWidth() - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
+    float const availWidth =
+        std::max(ImGui::GetContentRegionAvailWidth() - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
     float const paddedIconWidth = iconWidth + style.ColumnsMinSpacing;
     int const columns = up::clamp(static_cast<int>(availWidth / paddedIconWidth), 1, 64);
 

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -171,7 +171,7 @@ ImVec2 ImGui::Potato::GetItemInnerSpacing() {
 bool ImGui::Potato::BeginIconGrid(char const* label, float iconWidth) {
     ImGuiStyle const& style = GetStyle();
     float const availWidth =
-        std::max(ImGui::GetContentRegionAvailWidth() - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
+        up::max(ImGui::GetContentRegionAvailWidth() - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
     float const paddedIconWidth = iconWidth + style.ColumnsMinSpacing;
     int const columns = up::clamp(static_cast<int>(availWidth / paddedIconWidth), 1, 64);
 

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -157,8 +157,10 @@ ImVec2 ImGui::Potato::GetItemInnerSpacing() {
 }
 
 bool ImGui::Potato::BeginIconGrid(char const* label, float iconWidth) {
-    float const availWidth = ImGui::GetContentRegionAvailWidth();
-    int const columns = up::clamp(static_cast<int>(availWidth / iconWidth), 1, 64);
+    ImGuiStyle const& style = GetStyle();
+    float const availWidth = std::max(ImGui::GetContentRegionAvailWidth() - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
+    float const paddedIconWidth = iconWidth + style.ColumnsMinSpacing;
+    int const columns = up::clamp(static_cast<int>(availWidth / paddedIconWidth), 1, 64);
 
     return ImGui::BeginTable(label, columns);
 }


### PR DESCRIPTION
- Only show direct children in main icon view
- Spacing tweaks and fixes
- Improved folder tree view and behavior
- Tweaks to back/forward/breadcrumb icons
- Added up folder button
- Condensed Add Asset / Add Folder buttons into a single dropdown