### PR TITLE
Various imgui fixes and tweaks

### DIFF
--- a/potato/bin_shell/include/potato/shell/editor.h
+++ b/potato/bin_shell/include/potato/shell/editor.h
@@ -87,6 +87,8 @@ namespace up::shell {
         bool isActive() const noexcept { return _active; }
         void activate(bool active, Actions& actions);
 
+        void resetLayout() noexcept { _wantReset = true; }
+
     protected:
         explicit Editor(zstring_view className);
 
@@ -95,11 +97,9 @@ namespace up::shell {
 
         void addPanel(string title, PanelDir dir, PanelUpdate update);
 
-        auto contentId() const noexcept { return _dockId; }
         void addAction(ActionDesc action) { _actions.addAction(std::move(action)); }
 
         /// @brief Renders the ui for the Document.
-        virtual void configure() = 0;
         virtual void content() = 0;
         virtual bool hasMenu() { return false; }
         virtual bool handleClose() { return true; }
@@ -108,10 +108,10 @@ namespace up::shell {
 
         ImGuiWindowClass _panelClass;
         ImGuiWindowClass _contentClass;
-        ImGuiID _dockId = 0;
 
         vector<box<Panel>> _panels;
         ActionGroup _actions;
+        bool _wantReset = false;
         bool _wantClose = false;
         bool _closed = false;
         bool _active = false;

--- a/potato/bin_shell/include/potato/shell/editor.h
+++ b/potato/bin_shell/include/potato/shell/editor.h
@@ -38,13 +38,21 @@ namespace up::shell {
         using PanelId = ImGuiID;
         using EditorId = uint64;
 
+        enum class PanelDir {
+            Right,
+            RightLower,
+            Left,
+            LeftLower,
+            Bottom
+        };
+
         struct Panel {
             string title;
             string imguiLabel;
             bool open = true;
             PanelUpdate update;
             ImGuiID id = 0;
-            ImGuiID dockId = 0;
+            PanelDir initialDir = PanelDir::Right;
         };
 
         virtual ~Editor() = default;
@@ -85,8 +93,8 @@ namespace up::shell {
         ImGuiWindowClass const& panelWindowClass() const noexcept { return _panelClass; }
         ImGuiWindowClass const& contentWindowClass() const noexcept { return _contentClass; }
 
-        auto addPanel(string title, PanelUpdate update) -> PanelId;
-        void dockPanel(PanelId panelId, ImGuiDir dir, PanelId otherId, float size);
+        void addPanel(string title, PanelDir dir, PanelUpdate update);
+
         auto contentId() const noexcept { return _dockId; }
         void addAction(ActionDesc action) { _actions.addAction(std::move(action)); }
 
@@ -97,7 +105,6 @@ namespace up::shell {
         virtual bool handleClose() { return true; }
 
     private:
-        void _content();
 
         ImGuiWindowClass _panelClass;
         ImGuiWindowClass _contentClass;

--- a/potato/bin_shell/include/potato/shell/editor.h
+++ b/potato/bin_shell/include/potato/shell/editor.h
@@ -38,13 +38,7 @@ namespace up::shell {
         using PanelId = ImGuiID;
         using EditorId = uint64;
 
-        enum class PanelDir {
-            Right,
-            RightLower,
-            Left,
-            LeftLower,
-            Bottom
-        };
+        enum class PanelDir { Right, RightLower, Left, LeftLower, Bottom };
 
         struct Panel {
             string title;
@@ -105,7 +99,6 @@ namespace up::shell {
         virtual bool handleClose() { return true; }
 
     private:
-
         ImGuiWindowClass _panelClass;
         ImGuiWindowClass _contentClass;
 

--- a/potato/bin_shell/source/editor.cpp
+++ b/potato/bin_shell/source/editor.cpp
@@ -11,12 +11,14 @@
 
 up::shell::Editor::Editor(zstring_view className) {
     _panelClass.ClassId = narrow_cast<ImU32>(reinterpret_cast<uintptr_t>(this));
+    _panelClass.TabItemFlagsOverrideSet = ImGuiTabItemFlags_NoCloseWithMiddleMouseButton;
     _panelClass.DockingAllowUnclassed = false;
-    _panelClass.DockingAlwaysTabBar = true;
+    _panelClass.DockingAlwaysTabBar = false;
 
     _contentClass.ClassId = narrow_cast<ImU32>(reinterpret_cast<uintptr_t>(this));
     _contentClass.DockNodeFlagsOverrideSet =
         ImGuiDockNodeFlags_NoCloseButton | ImGuiDockNodeFlags_NoDockingOverMe | ImGuiDockNodeFlags_NoTabBar;
+    _contentClass.TabItemFlagsOverrideSet = ImGuiTabItemFlags_NoCloseWithMiddleMouseButton;
     _contentClass.DockingAllowUnclassed = false;
     _contentClass.DockingAlwaysTabBar = false;
 }
@@ -28,14 +30,16 @@ bool up::shell::Editor::updateUi() {
     nanofmt::format_to(editorTitle, "{}##{}", displayName(), this);
     nanofmt::format_to(contentTitle, "Document##{}", this);
 
+    ImGuiWindowFlags const windowFlags = ImGuiWindowFlags_NoCollapse;
+
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
     if (isClosable()) {
         bool wantOpen = true;
-        ImGui::Begin(editorTitle, &wantOpen, ImGuiWindowFlags_NoCollapse);
+        ImGui::Begin(editorTitle, &wantOpen, windowFlags);
         _wantClose = _wantClose || !wantOpen;
     }
     else {
-        ImGui::Begin(editorTitle, nullptr, ImGuiWindowFlags_NoCollapse);
+        ImGui::Begin(editorTitle, nullptr, windowFlags);
     }
     ImGui::PopStyleVar(1);
 
@@ -43,7 +47,7 @@ bool up::shell::Editor::updateUi() {
     if (ImGui::DockBuilderGetNode(dockSpaceId) == nullptr) {
         _dockId = ImGui::DockBuilderAddNode(
             dockSpaceId,
-            ImGuiDockNodeFlags_DockSpace | ImGuiDockNodeFlags_NoWindowMenuButton);
+            ImGuiDockNodeFlags_CentralNode | ImGuiDockNodeFlags_NoWindowMenuButton);
 
         configure();
 

--- a/potato/bin_shell/source/editor.cpp
+++ b/potato/bin_shell/source/editor.cpp
@@ -149,7 +149,8 @@ bool up::shell::Editor::updateUi() {
         _closed = handleClose();
     }
 
-    auto const active = ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows);
+    auto const active =
+        isEditorOpen && ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows | ImGuiFocusedFlags_DockHierarchy);
 
     ImGui::End();
 

--- a/potato/bin_shell/source/editor.cpp
+++ b/potato/bin_shell/source/editor.cpp
@@ -38,13 +38,14 @@ bool up::shell::Editor::updateUi() {
     ImGuiWindowFlags const windowFlags = ImGuiWindowFlags_NoCollapse;
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+    bool isEditorOpen = false;
     if (isClosable()) {
         bool wantOpen = true;
-        ImGui::Begin(editorTitle, &wantOpen, windowFlags);
+        isEditorOpen = ImGui::Begin(editorTitle, &wantOpen, windowFlags);
         _wantClose = _wantClose || !wantOpen;
     }
     else {
-        ImGui::Begin(editorTitle, nullptr, windowFlags);
+        isEditorOpen = ImGui::Begin(editorTitle, nullptr, windowFlags);
     }
     ImGui::PopStyleVar(1);
 
@@ -115,26 +116,32 @@ bool up::shell::Editor::updateUi() {
         ImGui::DockBuilderFinish(dockSpaceId);
     }
 
-    ImGui::DockSpace(dockSpaceId, {}, ImGuiDockNodeFlags_None, &_panelClass);
+    ImGui::DockSpace(
+        dockSpaceId,
+        {},
+        isEditorOpen ? ImGuiDockNodeFlags_None : ImGuiDockNodeFlags_KeepAliveOnly,
+        &_panelClass);
 
-    ImGui::SetNextWindowClass(&_contentClass);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
-    auto const contentOpen = ImGui::Begin(contentTitle, nullptr, ImGuiWindowFlags_NoCollapse);
-    ImGui::PopStyleVar(1);
+    if (isEditorOpen) {
+        ImGui::SetNextWindowClass(&_contentClass);
+        ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
+        auto const contentOpen = ImGui::Begin(contentTitle, nullptr, ImGuiWindowFlags_NoCollapse);
+        ImGui::PopStyleVar(1);
 
-    if (contentOpen) {
-        content();
-    }
+        if (contentOpen) {
+            content();
+        }
 
-    ImGui::End();
+        ImGui::End();
 
-    for (auto const& panel : _panels) {
-        if (panel->open) {
-            ImGui::SetNextWindowClass(&_panelClass);
-            if (ImGui::Begin(panel->imguiLabel.c_str(), &panel->open, ImGuiWindowFlags_NoCollapse)) {
-                panel->update();
+        for (auto const& panel : _panels) {
+            if (panel->open) {
+                ImGui::SetNextWindowClass(&_panelClass);
+                if (ImGui::Begin(panel->imguiLabel.c_str(), &panel->open, ImGuiWindowFlags_NoCollapse)) {
+                    panel->update();
+                }
+                ImGui::End();
             }
-            ImGui::End();
         }
     }
 

--- a/potato/bin_shell/source/editors/asset_browser.cpp
+++ b/potato/bin_shell/source/editors/asset_browser.cpp
@@ -58,16 +58,25 @@ namespace up::shell {
     } // namespace
 } // namespace up::shell
 
+up::shell::AssetBrowser::AssetBrowser(
+    AssetLoader& assetLoader,
+    ReconClient& reconClient,
+    AssetEditService& assetEditService,
+    OnFileSelected& onFileSelected)
+    : Editor("AssetBrowser"_zsv)
+    , _assetLoader(assetLoader)
+    , _assetEditService(assetEditService)
+    , _reconClient(reconClient)
+    , _onFileSelected(onFileSelected) {
+    _rebuild();
+}
+
 auto up::shell::AssetBrowser::createFactory(
     AssetLoader& assetLoader,
     ReconClient& reconClient,
     AssetEditService& assetEditService,
     AssetBrowser::OnFileSelected onFileSelected) -> box<EditorFactory> {
     return new_box<AssetBrowserFactory>(assetLoader, reconClient, assetEditService, std::move(onFileSelected));
-}
-
-void up::shell::AssetBrowser::configure() {
-    _rebuild();
 }
 
 void up::shell::AssetBrowser::content() {

--- a/potato/bin_shell/source/editors/asset_browser.h
+++ b/potato/bin_shell/source/editors/asset_browser.h
@@ -30,12 +30,7 @@ namespace up::shell {
             AssetLoader& assetLoader,
             ReconClient& reconClient,
             AssetEditService& assetEditService,
-            OnFileSelected& onFileSelected)
-            : Editor("AssetBrowser"_zsv)
-            , _assetLoader(assetLoader)
-            , _assetEditService(assetEditService)
-            , _reconClient(reconClient)
-            , _onFileSelected(onFileSelected) { }
+            OnFileSelected& onFileSelected);
 
         zstring_view displayName() const override { return "Assets"; }
         zstring_view editorClass() const override { return editorName; }
@@ -48,7 +43,6 @@ namespace up::shell {
             AssetBrowser::OnFileSelected onFileSelected);
 
     protected:
-        void configure() override;
         void content() override;
         bool isClosable() override { return false; }
 

--- a/potato/bin_shell/source/editors/game_editor.cpp
+++ b/potato/bin_shell/source/editors/game_editor.cpp
@@ -20,14 +20,14 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 
-auto up::shell::createGameEditor(box<Space> space) -> box<Editor> {
-    return new_box<GameEditor>(std::move(space));
-}
-
-void up::shell::GameEditor::configure() {
+up::shell::GameEditor::GameEditor(box<Space> space) : Editor("GameEditor"_zsv), _space(std::move(space)) {
     addAction({.command = "Play / Pause", .menu = "Actions\\Play/Pause", .hotKey = "F5", .action = [this] {
                    _paused = !_paused;
                }});
+}
+
+auto up::shell::createGameEditor(box<Space> space) -> box<Editor> {
+    return new_box<GameEditor>(std::move(space));
 }
 
 void up::shell::GameEditor::content() {

--- a/potato/bin_shell/source/editors/game_editor.h
+++ b/potato/bin_shell/source/editors/game_editor.h
@@ -18,14 +18,13 @@ namespace up {
 namespace up::shell {
     class GameEditor : public Editor {
     public:
-        explicit GameEditor(box<Space> space) : Editor("GameEditor"_zsv), _space(std::move(space)) { }
+        explicit GameEditor(box<Space> space);
 
         zstring_view displayName() const override { return "Game"_zsv; }
         zstring_view editorClass() const override { return "potato.editor.game"_zsv; }
         EditorId uniqueId() const override { return hash_value(this); }
 
     protected:
-        void configure() override;
         void content() override;
         void tick(float deltaTime) override;
         void render(Renderer& renderer, float deltaTime) override;

--- a/potato/bin_shell/source/editors/log_window.h
+++ b/potato/bin_shell/source/editors/log_window.h
@@ -25,7 +25,6 @@ namespace up::shell {
 
         static box<EditorFactory> createFactory(LogHistory& history);
 
-        void configure() override { }
         void content() override;
 
     private:

--- a/potato/bin_shell/source/editors/material_editor.cpp
+++ b/potato/bin_shell/source/editors/material_editor.cpp
@@ -41,14 +41,12 @@ up::shell::MaterialEditor::MaterialEditor(AssetLoader& assetLoader, box<schema::
     : Editor(editorName)
     , _assetLoader(assetLoader)
     , _material(std::move(material))
-    , _filename(std::move(filename)) { }
+    , _filename(std::move(filename)) {
+    _propertyGrid.bindResourceLoader(&_assetLoader);
+}
 
 auto up::shell::MaterialEditor::createFactory(AssetLoader& assetLoader) -> box<EditorFactory> {
     return new_box<MaterialEditorFactory>(assetLoader);
-}
-
-void up::shell::MaterialEditor::configure() {
-    _propertyGrid.bindResourceLoader(&_assetLoader);
 }
 
 void up::shell::MaterialEditor::content() {

--- a/potato/bin_shell/source/editors/material_editor.h
+++ b/potato/bin_shell/source/editors/material_editor.h
@@ -24,7 +24,6 @@ namespace up::shell {
         EditorId uniqueId() const override { return hash_value(this); }
 
     private:
-        void configure() override;
         void content() override;
 
         void _save();

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -110,22 +110,7 @@ namespace up::shell {
         _arcball.target = {0, 0, 0};
         _arcball.boomLength = 40.f;
         _arcball.pitch = -glm::quarter_pi<float>();
-    }
 
-    auto SceneEditor::createFactory(
-        SceneDatabase& database,
-        AssetLoader& assetLoader,
-        SceneEditor::HandlePlayClicked onPlayClicked) -> box<EditorFactory> {
-        return new_box<SceneEditorFactory>(database, assetLoader, std::move(onPlayClicked));
-    }
-
-    void SceneEditor::tick(float deltaTime) {
-        _doc->syncPreview(*_previewScene);
-
-        _previewScene->update(deltaTime);
-    }
-
-    void SceneEditor::configure() {
         addPanel("Inspector", PanelDir::Right, [this] { _inspector(); });
         addPanel("Hierarchy", PanelDir::Left, [this] { _hierarchy(); });
 
@@ -148,6 +133,19 @@ namespace up::shell {
                  [this]() {
                      _enableGrid = !_enableGrid;
                  }});
+    }
+
+    auto SceneEditor::createFactory(
+        SceneDatabase& database,
+        AssetLoader& assetLoader,
+        SceneEditor::HandlePlayClicked onPlayClicked) -> box<EditorFactory> {
+        return new_box<SceneEditorFactory>(database, assetLoader, std::move(onPlayClicked));
+    }
+
+    void SceneEditor::tick(float deltaTime) {
+        _doc->syncPreview(*_previewScene);
+
+        _previewScene->update(deltaTime);
     }
 
     void SceneEditor::content() {

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -126,11 +126,8 @@ namespace up::shell {
     }
 
     void SceneEditor::configure() {
-        auto const inspectorId = addPanel("Inspector", [this] { _inspector(); });
-        auto const hierarchyId = addPanel("Hierarchy", [this] { _hierarchy(); });
-
-        dockPanel(inspectorId, ImGuiDir_Right, contentId(), 0.25f);
-        dockPanel(hierarchyId, ImGuiDir_Down, inspectorId, 0.65f);
+        addPanel("Inspector", PanelDir::Right, [this] { _inspector(); });
+        addPanel("Hierarchy", PanelDir::Left, [this] { _hierarchy(); });
 
         addAction(
             {.name = "potato.editors.scene.actions.play",
@@ -156,12 +153,6 @@ namespace up::shell {
     void SceneEditor::content() {
         auto& io = ImGui::GetIO();
 
-        auto const contentSize = ImGui::GetContentRegionAvail();
-
-        if (contentSize.x <= 0 || contentSize.y <= 0) {
-            return;
-        }
-
         ImGui::BeginGroup();
         if (ImGui::IconButton("Play", ICON_FA_PLAY)) {
             _onPlayClicked(*_doc);
@@ -171,6 +162,11 @@ namespace up::shell {
             _save();
         }
         ImGui::EndGroup();
+
+        auto const contentSize = ImGui::GetContentRegionAvail();
+        if (contentSize.x <= 0 || contentSize.y <= 0) {
+            return;
+        }
 
         {
             _sceneDimensions = {contentSize.x, contentSize.y};

--- a/potato/bin_shell/source/editors/scene_editor.h
+++ b/potato/bin_shell/source/editors/scene_editor.h
@@ -44,7 +44,6 @@ namespace up::shell {
         void tick(float deltaTime) override;
 
     protected:
-        void configure() override;
         void content() override;
         void render(Renderer& renderer, float deltaTime) override;
 

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -95,11 +95,17 @@ int up::shell::ShellApp::initialize() {
         _logger.info("Loaded user settings: ", _shellSettingsPath);
     }
 
-    ImGui::CreateContext();
-    auto& io = ImGui::GetIO();
-    io.ConfigFlags =
-        ImGuiConfigFlags_DockingEnable | ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_ViewportsEnable;
-    io.ConfigInputTextCursorBlink = true;
+    {
+        ImGui::CreateContext();
+        auto& io = ImGui::GetIO();
+        io.ConfigFlags =
+            ImGuiConfigFlags_DockingEnable | ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_ViewportsEnable;
+        io.ConfigInputTextCursorBlink = true;
+        io.ConfigWindowsMoveFromTitleBarOnly = true;
+
+        auto& style = ImGui::GetStyle();
+        style.WindowMenuButtonPosition = ImGuiDir_None;
+    }
 
     _appActions.addAction(
         {.name = "potato.quit",

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -570,21 +570,7 @@ void up::shell::ShellApp::_displayMainMenu() {
 }
 
 void up::shell::ShellApp::_displayDocuments() {
-    auto const windowFlags = ImGuiWindowFlags_NoDocking | ImGuiWindowFlags_NoDecoration |
-        ImGuiWindowFlags_NoBackground | ImGuiWindowFlags_NoBringToFrontOnFocus;
-
-    ImGuiViewport const* const viewport = ImGui::GetMainViewport();
-
-    ImGui::SetNextWindowPos(viewport->WorkPos);
-    ImGui::SetNextWindowSize(viewport->WorkSize);
-    ImGui::SetNextWindowViewport(viewport->ID);
-    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, {0, 0});
-    ImGui::Begin("MainWindow", nullptr, windowFlags);
-    ImGui::PopStyleVar(1);
-
     _editors.update(*_renderer, _lastFrameTime);
-
-    ImGui::End();
 }
 
 void up::shell::ShellApp::_errorDialog(zstring_view message) {

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -485,54 +485,8 @@ void up::shell::ShellApp::_updateTitle() {
 void up::shell::ShellApp::_processEvents() {
     ZoneScopedN("Shell Events");
 
-    auto& io = ImGui::GetIO();
-
     // TODO: https://github.com/potatoengine/potato/issues/305
     // SDL_SetRelativeMouseMode(ImGui::IsCaptureRelativeMouseMode() ? SDL_TRUE : SDL_FALSE);
-
-    SDL_CaptureMouse(io.WantCaptureMouse ? SDL_TRUE : SDL_FALSE);
-
-    auto const guiCursor = ImGui::GetMouseCursor();
-    if (guiCursor != _lastCursor) {
-        _lastCursor = guiCursor;
-        SDL_ShowCursor(guiCursor != ImGuiMouseCursor_None ? SDL_TRUE : SDL_FALSE);
-        if (guiCursor == ImGuiMouseCursor_Arrow) {
-            SDL_SetCursor(SDL_GetDefaultCursor());
-            _cursor.reset();
-        }
-        else {
-            switch (guiCursor) {
-                case ImGuiMouseCursor_TextInput:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_IBEAM));
-                    break;
-                case ImGuiMouseCursor_ResizeAll:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEALL));
-                    break;
-                case ImGuiMouseCursor_ResizeNS:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENS));
-                    break;
-                case ImGuiMouseCursor_ResizeEW:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZEWE));
-                    break;
-                case ImGuiMouseCursor_ResizeNESW:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENESW));
-                    break;
-                case ImGuiMouseCursor_ResizeNWSE:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_SIZENWSE));
-                    break;
-                case ImGuiMouseCursor_Hand:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_HAND));
-                    break;
-                case ImGuiMouseCursor_NotAllowed:
-                    _cursor.reset(SDL_CreateSystemCursor(SDL_SYSTEM_CURSOR_NO));
-                    break;
-                default:
-                    _cursor.reset(SDL_GetDefaultCursor());
-                    break;
-            }
-            SDL_SetCursor(_cursor.get());
-        }
-    }
 
     SDL_Event ev;
     while (_running && SDL_PollEvent(&ev) > 0) {

--- a/potato/bin_shell/source/shell_app.h
+++ b/potato/bin_shell/source/shell_app.h
@@ -102,7 +102,6 @@ namespace up::shell {
         HotKeys _hotKeys;
         EditorGroup _editors;
         vector<box<EditorFactory>> _editorFactories;
-        int _lastCursor = -1;
         Logger _logger;
         float _lastFrameTime = 0.f;
         std::chrono::nanoseconds _lastFrameDuration = {};

--- a/potato/bin_shell/source/ui/editor_group.cpp
+++ b/potato/bin_shell/source/ui/editor_group.cpp
@@ -11,7 +11,7 @@
 
 up::shell::EditorGroup::EditorGroup(Actions& actions) : _actions(actions) {
     _documentWindowClass.ClassId = narrow_cast<ImU32>(reinterpret_cast<uintptr_t>(this));
-    _documentWindowClass.DockNodeFlagsOverrideSet = ImGuiDockNodeFlags_AutoHideTabBar;
+    _documentWindowClass.DockNodeFlagsOverrideSet = ImGuiDockNodeFlags_AutoHideTabBar | ImGuiDockNodeFlags_NoSplit;
     _documentWindowClass.TabItemFlagsOverrideSet = ImGuiTabItemFlags_NoCloseWithMiddleMouseButton;
     _documentWindowClass.DockingAllowUnclassed = false;
     _documentWindowClass.DockingAlwaysTabBar = false;

--- a/potato/bin_shell/source/ui/editor_group.cpp
+++ b/potato/bin_shell/source/ui/editor_group.cpp
@@ -34,8 +34,7 @@ void up::shell::EditorGroup::update(Renderer& renderer, float deltaTime) {
         _editors[index]->tick(deltaTime);
     }
 
-    auto const dockspaceId = ImGui::GetID("EditorDockspace");
-    ImGui::DockSpace(dockspaceId, {}, ImGuiDockNodeFlags_NoWindowMenuButton, &_documentWindowClass);
+    auto const dockspaceId = ImGui::DockSpaceOverViewport(nullptr, 0, &_documentWindowClass);
 
     for (auto index : sequence(_editors.size())) {
         Editor* editor = _editors[index].get();

--- a/potato/bin_shell/source/ui/editor_group.cpp
+++ b/potato/bin_shell/source/ui/editor_group.cpp
@@ -11,8 +11,10 @@
 
 up::shell::EditorGroup::EditorGroup(Actions& actions) : _actions(actions) {
     _documentWindowClass.ClassId = narrow_cast<ImU32>(reinterpret_cast<uintptr_t>(this));
+    _documentWindowClass.DockNodeFlagsOverrideSet = ImGuiDockNodeFlags_AutoHideTabBar;
+    _documentWindowClass.TabItemFlagsOverrideSet = ImGuiTabItemFlags_NoCloseWithMiddleMouseButton;
     _documentWindowClass.DockingAllowUnclassed = false;
-    _documentWindowClass.DockingAlwaysTabBar = true;
+    _documentWindowClass.DockingAlwaysTabBar = false;
 }
 
 up::shell::EditorGroup::~EditorGroup() = default;


### PR DESCRIPTION
- Style tweaks to editor windows and panels
- Removed redundant SDL code (implemented in default backend)
- Fix: docking an editor window with another no longer causes overlay artefacts
- Fix: undocking windows is smooth and continuous
- Refactor panel layout configuration (implementation is gross)
- Disallow splitting top-level editor windows
- Fix: bug allowing content node of Asset Browser to become undocked
- Added a Panels/Reset Layout menu option for all editor windows
- Fix: activate new editor windows so menu bar is updated
- Windows can only be dragged from the titlebar
- Changed default panel layout for Scene Editor

![image](https://user-images.githubusercontent.com/1817473/151500722-b3b7bcdc-9ee8-4856-aacd-8a41a49ebd7b.png)
