### PR TITLE
Editor tweaks

### DIFF
--- a/potato/bin_shell/source/editors/log_window.cpp
+++ b/potato/bin_shell/source/editors/log_window.cpp
@@ -77,7 +77,7 @@ void up::shell::LogWindow::content(CommandManager&) {
     }
 
     ImVec2 const statusSize = ImVec2(
-        ImGui::GetContentRegionAvailWidth(),
+        ImGui::GetContentRegionAvail().x,
         ImGui::GetTextLineHeightWithSpacing() + ImGui::GetStyle().ItemSpacing.y);
 
     ImGui::BeginChildFrame(

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -241,6 +241,8 @@ int up::shell::ShellApp::initialize() {
             ImGuiConfigFlags_DockingEnable | ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_ViewportsEnable;
         io.ConfigInputTextCursorBlink = true;
         io.ConfigWindowsMoveFromTitleBarOnly = true;
+        io.ConfigViewportsNoAutoMerge = true;
+        io.ConfigDockingTransparentPayload = true;
 
         auto& style = ImGui::GetStyle();
         style.WindowMenuButtonPosition = ImGuiDir_None;

--- a/potato/libeditor/source/editor_manager.cpp
+++ b/potato/libeditor/source/editor_manager.cpp
@@ -100,7 +100,7 @@ namespace up {
 
             _currentEditorId = editor->uniqueId();
 
-            ImGui::SetNextWindowDockID(dockspaceId, ImGuiCond_FirstUseEver);
+            ImGui::SetNextWindowDockID(dockspaceId, editor->isCloseable() ? ImGuiCond_FirstUseEver : ImGuiCond_Always);
             ImGui::SetNextWindowClass(&_documentWindowClass);
             if (!_focusedEditorId) {
                 ImGui::SetNextWindowFocus();

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -166,7 +166,7 @@ namespace ImGui::inline Potato {
     bool BeginIconGrid(char const* label, float iconWidth) {
         ImGuiStyle const& style = GetStyle();
         float const availWidth =
-            up::max(ImGui::GetContentRegionAvailWidth() - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
+            up::max(ImGui::GetContentRegionAvail().x - style.WindowPadding.x - style.FramePadding.x * 2.f, 0.f);
         float const paddedIconWidth = iconWidth + style.ColumnsMinSpacing;
         int const columns = up::clamp(static_cast<int>(availWidth / paddedIconWidth), 1, 64);
 

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -284,7 +284,7 @@ namespace ImGui::inline Potato {
         style.WindowPadding = ImVec2(4.0f, 4.0f);
         style.FramePadding = ImVec2(4.0f, 4.0f);
 
-        style.WindowBorderSize = 1.0f;
+        style.WindowBorderSize = 2.0f;
         style.ChildBorderSize = 1.0f;
         style.PopupBorderSize = 1.0f;
         style.FrameBorderSize = 1.0f;

--- a/potato/libeditor/source/property_grid.cpp
+++ b/potato/libeditor/source/property_grid.cpp
@@ -171,7 +171,7 @@ bool up::editor::PropertyGrid::_editArrayField(
 
         // Icon for deleting a row
         if (schema.operations->arrayEraseAt != nullptr) {
-            float const availWidth = ImGui::GetContentRegionAvailWidth();
+            float const availWidth = ImGui::GetContentRegionAvail().x;
             float const buttonWidth = ImGui::GetFontSize() + ImGui::GetStyle().FramePadding.x * 2.f;
             float const adjustWidth = availWidth - buttonWidth;
             ImGui::SetCursorPos({ImGui::GetCursorPosX() + adjustWidth, rowY});
@@ -192,7 +192,7 @@ bool up::editor::PropertyGrid::_editArrayField(
         ImGui::TableNextRow();
         ImGui::TableSetColumnIndex(0);
         ImGui::AlignTextToFramePadding();
-        float const availWidth = ImGui::GetContentRegionAvailWidth();
+        float const availWidth = ImGui::GetContentRegionAvail().x;
         float const buttonWidth = ImGui::GetFontSize() + ImGui::GetStyle().FramePadding.x * 2.f;
         float const adjustWidth = availWidth - buttonWidth;
         ImGui::SetCursorPosX(ImGui::GetCursorPosX() + adjustWidth);


### PR DESCRIPTION
- Slightly wider borders on windows
- Windows are transparent during docking
- Ensure Assets editor remains docked in the main window
- Remove some deprecated ImGui functions

Note: I tried upgrading to the latest imgui docking branch commit, which fixes a few bugs we're encountering... unfortunately it also _added_ a couple more serious bugs. Will wait for the next imgui release before we try that again.