### PR TITLE
Property Grid updates

### DIFF
--- a/potato/bin_shell/schema/scene.sap
+++ b/potato/bin_shell/schema/scene.sap
@@ -40,3 +40,15 @@ scene_component Body {
     float mass = 1;
 }
 
+scene_component Test {
+    string text = "test";
+    int integer = 42;
+    [IntRange(-10,10)]
+    int limit;
+    float real = -7;
+    UUID ref;
+    vec3 vec;
+    quat rot;
+    bool enabled;
+}
+

--- a/potato/bin_shell/schema/scene.sap
+++ b/potato/bin_shell/schema/scene.sap
@@ -50,25 +50,25 @@ scene_component Body {
 }
 
 scene_component Test {
-    [DisplayName("Words")]
+    [DisplayName("Wordy Name")]
     string text = "test";
 
     int integer = 42;
     [IntRange(-10,10)]
-    int limit;
+    int _limit10;
 
-    float real = -7;
+    float real_number = -7;
 
     [DisplayName("Reference")]
-    UUID ref;
+    UUID ref_uuid;
 
     [Tooltip("This is a handy tip")]
-    vec3 vec;
-    quat rot;
+    vec3 position;
+    quat rotation;
     bool enabled;
     Euler angles;
-    Euler* embedded;
-    Euler[] array;
     int[] numbers;
+    Euler[] euler_array;
+    Euler* euler_object;
 }
 

--- a/potato/bin_shell/schema/scene.sap
+++ b/potato/bin_shell/schema/scene.sap
@@ -9,6 +9,15 @@ import sound;
 [cxxnamespace("up::scene::components")]
 use scene_component : struct;
 
+struct Euler {
+    [FloatRange(-180,180)]
+    float pitch;
+    [FloatRange(-180,180)]
+    float yaw;
+    [FloatRange(-180,180)]
+    float roll;
+}
+
 scene_component Transform {
     [DisplayName("Pos")]
     vec3 position;
@@ -41,14 +50,25 @@ scene_component Body {
 }
 
 scene_component Test {
+    [DisplayName("Words")]
     string text = "test";
+
     int integer = 42;
     [IntRange(-10,10)]
     int limit;
+
     float real = -7;
+
+    [DisplayName("Reference")]
     UUID ref;
+
+    [Tooltip("This is a handy tip")]
     vec3 vec;
     quat rot;
     bool enabled;
+    Euler angles;
+    Euler* embedded;
+    Euler[] array;
+    int[] numbers;
 }
 

--- a/potato/bin_shell/source/edit_components.h
+++ b/potato/bin_shell/source/edit_components.h
@@ -78,4 +78,16 @@ namespace up {
     class BodyEditComponent final : public SimpleEditComponent<scene::components::Body, RigidBodyComponent> {
         RigidBodyComponent createFrom(scene::components::Body const& sceneComponent) const override;
     };
+
+    class TestEditComponent final : public EditComponent {
+    public:
+        zstring_view name() const noexcept final { return typeInfo().name; }
+        reflex::TypeInfo const& typeInfo() const noexcept final {
+            return reflex::getTypeInfo<scene::components::Test>();
+        }
+        bool syncAdd(Space&, EntityId, SceneComponent const&) const final { return false; }
+        bool syncUpdate(Space&, EntityId, SceneComponent const&) const final { return false; }
+        bool syncRemove(Space&, EntityId, SceneComponent const&) const final { return false; }
+        bool syncGame(Space& space, EntityId entityId, SceneComponent const& component) const final { return false; }
+    };
 } // namespace up

--- a/potato/bin_shell/source/editors/material_editor.cpp
+++ b/potato/bin_shell/source/editors/material_editor.cpp
@@ -68,17 +68,10 @@ void up::shell::MaterialEditor::content(CommandManager&) {
     }
     ImGui::EndGroup();
 
-    if (!ImGui::BeginTable(
-            "##material",
-            2,
-            ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize |
-                ImGuiTableFlags_SizingStretchProp)) {
-        return;
+    if (_propertyGrid.beginTable()) {
+        _propertyGrid.editObject(*_material);
+        _propertyGrid.endTable();
     }
-
-    _propertyGrid.editObject(*_material);
-
-    ImGui::EndTable();
 }
 
 void up::shell::MaterialEditor::_save() {

--- a/potato/bin_shell/source/editors/material_editor.cpp
+++ b/potato/bin_shell/source/editors/material_editor.cpp
@@ -15,9 +15,7 @@ namespace up::shell {
     namespace {
         class MaterialEditorFactory : public EditorFactory<MaterialEditor> {
         public:
-            MaterialEditorFactory(PropertyGrid& propertyGrid, AssetLoader& assetLoader) noexcept
-                : _propertyGrid(propertyGrid)
-                , _assetLoader(assetLoader) { }
+            explicit MaterialEditorFactory(PropertyGrid& propertyGrid) noexcept : _propertyGrid(propertyGrid) { }
 
             box<EditorBase> createEditor(EditorParams const& params) override {
                 if (auto [rs, text] = fs::readText(params.documentPath); rs == IOResult::Success) {
@@ -27,7 +25,6 @@ namespace up::shell {
                         return new_box<MaterialEditor>(
                             params,
                             _propertyGrid,
-                            _assetLoader,
                             std::move(material),
                             string(params.documentPath));
                     }
@@ -37,7 +34,6 @@ namespace up::shell {
 
         private:
             PropertyGrid& _propertyGrid;
-            AssetLoader& _assetLoader;
         };
     } // namespace
 } // namespace up::shell
@@ -45,20 +41,15 @@ namespace up::shell {
 up::shell::MaterialEditor::MaterialEditor(
     EditorParams const& params,
     PropertyGrid& propertyGrid,
-    AssetLoader& assetLoader,
     box<schema::Material> material,
     string filename)
     : Editor(params)
-    , _assetLoader(assetLoader)
     , _material(std::move(material))
     , _filename(std::move(filename))
     , _propertyGrid(propertyGrid) { }
 
-void up::shell::MaterialEditor::addFactory(
-    EditorManager& editors,
-    PropertyGrid& propertyGrid,
-    AssetLoader& assetLoader) {
-    editors.addFactory<MaterialEditorFactory>(propertyGrid, assetLoader);
+void up::shell::MaterialEditor::addFactory(EditorManager& editors, PropertyGrid& propertyGrid) {
+    editors.addFactory<MaterialEditorFactory>(propertyGrid);
 }
 
 void up::shell::MaterialEditor::content(CommandManager&) {

--- a/potato/bin_shell/source/editors/material_editor.h
+++ b/potato/bin_shell/source/editors/material_editor.h
@@ -19,11 +19,10 @@ namespace up::shell {
         MaterialEditor(
             EditorParams const& params,
             PropertyGrid& propertyGrid,
-            AssetLoader& assetLoader,
             box<schema::Material> material,
             string filename);
 
-        static void addFactory(EditorManager& editors, PropertyGrid& propertyGrid, AssetLoader& assetLoader);
+        static void addFactory(EditorManager& editors, PropertyGrid& propertyGrid);
 
         zstring_view displayName() const override { return "Material"_zsv; }
 
@@ -32,7 +31,6 @@ namespace up::shell {
 
         void _save();
 
-        AssetLoader& _assetLoader;
         box<schema::Material> _material;
         string _filename;
         PropertyGrid& _propertyGrid;

--- a/potato/bin_shell/source/editors/material_editor.h
+++ b/potato/bin_shell/source/editors/material_editor.h
@@ -23,10 +23,7 @@ namespace up::shell {
             box<schema::Material> material,
             string filename);
 
-        static void addFactory(
-            EditorManager& editors,
-            PropertyGrid& propertyGrid,
-            AssetLoader& assetLoader);
+        static void addFactory(EditorManager& editors, PropertyGrid& propertyGrid, AssetLoader& assetLoader);
 
         zstring_view displayName() const override { return "Material"_zsv; }
 

--- a/potato/bin_shell/source/editors/material_editor.h
+++ b/potato/bin_shell/source/editors/material_editor.h
@@ -38,6 +38,6 @@ namespace up::shell {
         AssetLoader& _assetLoader;
         box<schema::Material> _material;
         string _filename;
-        PropertyGrid _propertyGrid;
+        PropertyGrid& _propertyGrid;
     };
 } // namespace up::shell

--- a/potato/bin_shell/source/editors/material_editor.h
+++ b/potato/bin_shell/source/editors/material_editor.h
@@ -8,6 +8,7 @@
 
 namespace up {
     class AssetLoader;
+    class PropertyGrid;
 } // namespace up
 
 namespace up::shell {
@@ -17,11 +18,15 @@ namespace up::shell {
 
         MaterialEditor(
             EditorParams const& params,
+            PropertyGrid& propertyGrid,
             AssetLoader& assetLoader,
             box<schema::Material> material,
             string filename);
 
-        static void addFactory(EditorManager& editors, AssetLoader& assetLoader);
+        static void addFactory(
+            EditorManager& editors,
+            PropertyGrid& propertyGrid,
+            AssetLoader& assetLoader);
 
         zstring_view displayName() const override { return "Material"_zsv; }
 

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -54,13 +54,7 @@ namespace up::shell {
                     doc->fromJson(jsonDoc, _assetLoader);
                 }
 
-                return new_box<SceneEditor>(
-                    params,
-                    std::move(doc),
-                    std::move(space),
-                    _database,
-                    _propertyGrid,
-                    _assetLoader);
+                return new_box<SceneEditor>(params, std::move(doc), std::move(space), _database, _propertyGrid);
             }
 
         private:
@@ -118,14 +112,12 @@ namespace up::shell {
         box<SceneDocument> sceneDoc,
         box<Space> previewScene,
         SceneDatabase& database,
-        PropertyGrid& propertyGrid,
-        AssetLoader& assetLoader)
+        PropertyGrid& propertyGrid)
         : Editor(params)
         , _previewScene(std::move(previewScene))
         , _doc(std::move(sceneDoc))
-        , _propertyGrid(propertyGrid)
         , _database(database)
-        , _assetLoader(assetLoader) {
+        , _propertyGrid(propertyGrid) {
         _arcball.target = {0, 0, 0};
         _arcball.boomLength = 40.f;
         _arcball.pitch = -glm::quarter_pi<float>();

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -345,7 +345,7 @@ namespace up::shell {
         for (auto& component : entity.components) {
             ImGui::PushID(component.get());
 
-            const bool open = _propertyGrid.beginItem(component->name.c_str());
+            const bool open = ImGui::ToggleHeader(component->name.c_str());
 
             if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(1)) {
                 ImGui::OpenPopup("##component_context_menu");
@@ -365,7 +365,6 @@ namespace up::shell {
                 if (_propertyGrid.editObjectRaw(*component->info->typeInfo().schema, component->data.get())) {
                     component->state = SceneComponent::State::Pending;
                 }
-                _propertyGrid.endItem();
             }
 
             ImGui::PopID();

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -39,8 +39,12 @@ namespace up::shell {
     namespace {
         class SceneEditorFactory : public EditorFactory<SceneEditor> {
         public:
-            SceneEditorFactory(SceneDatabase& database, AssetLoader& assetLoader)
+            SceneEditorFactory(
+                SceneDatabase& database,
+                PropertyGrid& propertyGrid,
+                AssetLoader& assetLoader)
                 : _database(database)
+                , _propertyGrid(propertyGrid)
                 , _assetLoader(assetLoader) { }
 
             box<EditorBase> createEditor(EditorParams const& params) override {
@@ -53,11 +57,18 @@ namespace up::shell {
                     doc->fromJson(jsonDoc, _assetLoader);
                 }
 
-                return new_box<SceneEditor>(params, std::move(doc), std::move(space), _database, _assetLoader);
+                return new_box<SceneEditor>(
+                    params,
+                    std::move(doc),
+                    std::move(space),
+                    _database,
+                    _propertyGrid,
+                    _assetLoader);
             }
 
         private:
             SceneDatabase& _database;
+            PropertyGrid& _propertyGrid;
             AssetLoader& _assetLoader;
         };
 
@@ -110,10 +121,12 @@ namespace up::shell {
         box<SceneDocument> sceneDoc,
         box<Space> previewScene,
         SceneDatabase& database,
+        PropertyGrid& propertyGrid,
         AssetLoader& assetLoader)
         : Editor(params)
         , _previewScene(std::move(previewScene))
         , _doc(std::move(sceneDoc))
+        , _propertyGrid(propertyGrid)
         , _database(database)
         , _assetLoader(assetLoader) {
         _arcball.target = {0, 0, 0};
@@ -131,8 +144,12 @@ namespace up::shell {
         }
     }
 
-    void SceneEditor::addFactory(EditorManager& editors, SceneDatabase& database, AssetLoader& assetLoader) {
-        editors.addFactory<SceneEditorFactory>(database, assetLoader);
+    void SceneEditor::addFactory(
+        EditorManager& editors,
+        SceneDatabase& database,
+        PropertyGrid& propertyGrid,
+        AssetLoader& assetLoader) {
+        editors.addFactory<SceneEditorFactory>(database, propertyGrid, assetLoader);
     }
 
     void SceneEditor::addCommands(CommandManager& commands) {
@@ -323,8 +340,6 @@ namespace up::shell {
         }
 
         ImGuiID const addComponentId = ImGui::GetID("##add_component_list");
-
-        _propertyGrid.bindResourceLoader(&_assetLoader);
 
         SceneEntity& entity = _doc->entityAt(index);
         for (auto& component : entity.components) {

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -328,18 +328,13 @@ namespace up::shell {
             }
         }
 
-        if (!_propertyGrid.beginTable()) {
-            return;
-        }
-
         ImGuiID const addComponentId = ImGui::GetID("##add_component_list");
 
         SceneEntity& entity = _doc->entityAt(index);
         for (auto& component : entity.components) {
-            ImGui::PushID(component.get());
-
             const bool open = ImGui::ToggleHeader(component->name.c_str());
 
+            ImGui::PushID(component->name.c_str());
             if (ImGui::IsItemHovered() && ImGui::IsMouseClicked(1)) {
                 ImGui::OpenPopup("##component_context_menu");
             }
@@ -353,17 +348,19 @@ namespace up::shell {
                 }
                 ImGui::EndPopup();
             }
-
-            if (open && component != nullptr) {
-                if (_propertyGrid.editObjectRaw(*component->info->typeInfo().schema, component->data.get())) {
-                    component->state = SceneComponent::State::Pending;
-                }
-            }
-
             ImGui::PopID();
-        }
 
-        _propertyGrid.endTable();
+            if (_propertyGrid.beginTable()) {
+                ImGui::PushID(component->name.c_str());
+                if (open && component != nullptr) {
+                    if (_propertyGrid.editObjectRaw(*component->info->typeInfo().schema, component->data.get())) {
+                        component->state = SceneComponent::State::Pending;
+                    }
+                }
+                ImGui::PopID();
+                _propertyGrid.endTable();
+            }
+        }
 
         erase(entity.components, nullptr);
 

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -125,6 +125,10 @@ namespace up::shell {
 
         commandScope().addHandler<PlayCommandHandler>(*this);
         commandScope().addHandler<ToggleGridHandler>(*this);
+
+        if (!_doc->indices().empty()) {
+            _selection.select(static_cast<SelectionId>(_doc->entityAt(0).sceneId));
+        }
     }
 
     void SceneEditor::addFactory(EditorManager& editors, SceneDatabase& database, AssetLoader& assetLoader) {

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -39,10 +39,7 @@ namespace up::shell {
     namespace {
         class SceneEditorFactory : public EditorFactory<SceneEditor> {
         public:
-            SceneEditorFactory(
-                SceneDatabase& database,
-                PropertyGrid& propertyGrid,
-                AssetLoader& assetLoader)
+            SceneEditorFactory(SceneDatabase& database, PropertyGrid& propertyGrid, AssetLoader& assetLoader)
                 : _database(database)
                 , _propertyGrid(propertyGrid)
                 , _assetLoader(assetLoader) { }

--- a/potato/bin_shell/source/editors/scene_editor.cpp
+++ b/potato/bin_shell/source/editors/scene_editor.cpp
@@ -331,11 +331,7 @@ namespace up::shell {
             }
         }
 
-        if (!ImGui::BeginTable(
-                "##inspector_table",
-                2,
-                ImGuiTableFlags_Resizable | ImGuiTableFlags_NoBordersInBodyUntilResize |
-                    ImGuiTableFlags_SizingStretchProp)) {
+        if (!_propertyGrid.beginTable()) {
             return;
         }
 
@@ -370,7 +366,7 @@ namespace up::shell {
             ImGui::PopID();
         }
 
-        ImGui::EndTable();
+        _propertyGrid.endTable();
 
         erase(entity.components, nullptr);
 

--- a/potato/bin_shell/source/editors/scene_editor.h
+++ b/potato/bin_shell/source/editors/scene_editor.h
@@ -22,7 +22,11 @@ namespace up::shell {
     public:
         static constexpr EditorTypeId editorTypeId{"potato.editor.scene"};
 
-        static void addFactory(EditorManager& editors, SceneDatabase& database, AssetLoader& assetLoader);
+        static void addFactory(
+            EditorManager& editors,
+            SceneDatabase& database,
+            PropertyGrid& propertyGrid,
+            AssetLoader& assetLoader);
         static void addCommands(CommandManager& commands);
 
         explicit SceneEditor(
@@ -30,6 +34,7 @@ namespace up::shell {
             box<SceneDocument> sceneDoc,
             box<Space> previewScene,
             SceneDatabase& database,
+            PropertyGrid& propertyGrid,
             AssetLoader& assetLoader);
 
         zstring_view displayName() const override { return "Scene"_zsv; }
@@ -64,7 +69,6 @@ namespace up::shell {
         box<GpuResourceView> _bufferView;
         ArcBall _arcball;
         SelectionState _selection;
-        PropertyGrid _propertyGrid;
         glm::ivec2 _sceneDimensions = {0, 0};
         bool _enableGrid = true;
         bool _create = false;
@@ -72,6 +76,7 @@ namespace up::shell {
         SceneEntityId _targetId = SceneEntityId::None;
         EntityId _cameraId = EntityId::None;
         SceneDatabase& _database;
+        PropertyGrid& _propertyGrid;
         AssetLoader& _assetLoader;
     };
 } // namespace up::shell

--- a/potato/bin_shell/source/editors/scene_editor.h
+++ b/potato/bin_shell/source/editors/scene_editor.h
@@ -34,8 +34,7 @@ namespace up::shell {
             box<SceneDocument> sceneDoc,
             box<Space> previewScene,
             SceneDatabase& database,
-            PropertyGrid& propertyGrid,
-            AssetLoader& assetLoader);
+            PropertyGrid& propertyGrid);
 
         zstring_view displayName() const override { return "Scene"_zsv; }
         zstring_view documentPath() const override { return _doc->filename(); }
@@ -77,6 +76,5 @@ namespace up::shell {
         EntityId _cameraId = EntityId::None;
         SceneDatabase& _database;
         PropertyGrid& _propertyGrid;
-        AssetLoader& _assetLoader;
     };
 } // namespace up::shell

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -348,7 +348,7 @@ int up::shell::ShellApp::initialize() {
         _openAssetEditor(uuid);
     });
     SceneEditor::addFactory(_editors, _sceneDatabase, _propertyGrid, _assetLoader);
-    MaterialEditor::addFactory(_editors, _propertyGrid, _assetLoader);
+    MaterialEditor::addFactory(_editors, _propertyGrid);
     LogWindow::addFactory(_editors, _logHistory);
     GameEditor::addFactory(_editors, *_audio);
 

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -197,7 +197,7 @@ namespace up {
     } // namespace
 } // namespace up
 
-up::shell::ShellApp::ShellApp() : _logger("shell") { }
+up::shell::ShellApp::ShellApp() : _logger("shell"), _propertyGrid(_assetLoader) { }
 
 up::shell::ShellApp::~ShellApp() {
     _renderer.reset();
@@ -346,8 +346,8 @@ int up::shell::ShellApp::initialize() {
     AssetBrowser::addFactory(_editors, _assetLoader, _reconClient, _assetEditService, [this](UUID const& uuid) {
         _openAssetEditor(uuid);
     });
-    SceneEditor::addFactory(_editors, _sceneDatabase, _assetLoader);
-    MaterialEditor::addFactory(_editors, _assetLoader);
+    SceneEditor::addFactory(_editors, _sceneDatabase, _propertyGrid, _assetLoader);
+    MaterialEditor::addFactory(_editors, _propertyGrid, _assetLoader);
     LogWindow::addFactory(_editors, _logHistory);
     GameEditor::addFactory(_editors, *_audio);
 

--- a/potato/bin_shell/source/shell_app.cpp
+++ b/potato/bin_shell/source/shell_app.cpp
@@ -342,6 +342,7 @@ int up::shell::ShellApp::initialize() {
     _sceneDatabase.registerComponent<SpinEditComponent>();
     _sceneDatabase.registerComponent<DingEditComponent>();
     _sceneDatabase.registerComponent<BodyEditComponent>();
+    _sceneDatabase.registerComponent<TestEditComponent>();
 
     AssetBrowser::addFactory(_editors, _assetLoader, _reconClient, _assetEditService, [this](UUID const& uuid) {
         _openAssetEditor(uuid);

--- a/potato/bin_shell/source/shell_app.h
+++ b/potato/bin_shell/source/shell_app.h
@@ -6,6 +6,7 @@
 #include "potato/editor/asset_edit_service.h"
 #include "potato/editor/command.h"
 #include "potato/editor/editor_manager.h"
+#include "potato/editor/property_grid.h"
 #include "potato/recon/recon_client.h"
 #include "potato/shell/log_history.h"
 #include "potato/shell/scene_doc.h"
@@ -94,6 +95,7 @@ namespace up::shell {
         std::chrono::nanoseconds _lastFrameDuration = {};
         string _projectName;
         AssetLoader _assetLoader;
+        PropertyGrid _propertyGrid;
         LogHistory _logHistory;
         ReconClient _reconClient;
         AssetEditService _assetEditService;

--- a/potato/libeditor/include/potato/editor/imgui_ext.h
+++ b/potato/libeditor/include/potato/editor/imgui_ext.h
@@ -8,10 +8,19 @@
 #include <glm/fwd.hpp>
 #include <imgui.h>
 
+inline namespace Potato {
+    enum ImGuiInteractiveFlags_ { ImGuiInteractiveFlags_None = 0, ImGuiInteractiveFlags_AllowItemOverlap };
+}
+
 namespace ImGui::inline Potato {
+
     UP_EDITOR_API bool BeginContextPopup();
 
     UP_EDITOR_API bool ToggleHeader(char const* label, char const* icon = nullptr) noexcept;
+
+    UP_EDITOR_API void Interactive(
+        char const* label,
+        ImGuiInteractiveFlags_ flags = ImGuiInteractiveFlags_None) noexcept;
 
     UP_EDITOR_API bool IconButton(
         char const* label,

--- a/potato/libeditor/include/potato/editor/imgui_ext.h
+++ b/potato/libeditor/include/potato/editor/imgui_ext.h
@@ -11,6 +11,8 @@
 namespace ImGui::inline Potato {
     UP_EDITOR_API bool BeginContextPopup();
 
+    UP_EDITOR_API bool ToggleHeader(char const* label, char const* icon = nullptr) noexcept;
+
     UP_EDITOR_API bool IconButton(
         char const* label,
         char const* icon,

--- a/potato/libeditor/include/potato/editor/property_grid.h
+++ b/potato/libeditor/include/potato/editor/property_grid.h
@@ -34,7 +34,7 @@ namespace up {
     public:
         explicit PropertyGrid(AssetLoader& assetLoader) noexcept;
 
-        bool beginTable();
+        bool beginTable(char const* label = nullptr);
         void endTable();
 
         bool editObjectRaw(reflex::Schema const& schema, void* object);

--- a/potato/libeditor/include/potato/editor/property_grid.h
+++ b/potato/libeditor/include/potato/editor/property_grid.h
@@ -19,22 +19,25 @@ namespace up {
         reflex::SchemaField const& field;
         reflex::Schema const& schema;
         void* object = nullptr;
+        int index = -1; // for arrays
+        bool canRemove = false; // if a remove icon should be present
     };
 
     class PropertyEditor {
     public:
         virtual ~PropertyEditor() = default;
 
-        virtual void label(PropertyInfo const& info);
         virtual bool edit(PropertyInfo const& info) = 0;
-        virtual bool expandable(PropertyInfo const& info) const { return false; }
     };
 
     class PropertyGrid {
     public:
         explicit PropertyGrid(AssetLoader& assetLoader) noexcept;
 
-        bool editObjectRaw(reflex::Schema const& schema, void* object) { return _editProperties(schema, object); }
+        bool beginTable();
+        void endTable();
+
+        bool editObjectRaw(reflex::Schema const& schema, void* object);
 
         template <typename T>
         void editObject(T& value) {
@@ -44,11 +47,15 @@ namespace up {
         void addPropertyEditor(box<PropertyEditor> editor);
 
     private:
-        bool _editProperties(reflex::Schema const& schema, void* object);
+        struct ArrayOps;
+        struct ItemState;
 
-        bool _editField(reflex::SchemaField const& field, reflex::Schema const& schema, void* object);
-        bool _drawObjectEditor(reflex::Schema const& schema, void* object);
-        bool _editArrayField(reflex::SchemaField const& field, reflex::Schema const& schema, void* object);
+        bool _editElements(PropertyInfo const& info, ItemState& state);
+        bool _editProperty(PropertyInfo const& info);
+
+        void _label(PropertyInfo const& info, ItemState& state, ArrayOps* ops = nullptr) noexcept;
+        bool _applyState(PropertyInfo const& info, ItemState const& state);
+        bool _editField(PropertyInfo const& info, ItemState& state, ArrayOps* ops = nullptr);
 
         PropertyEditor* _selectEditor(PropertyInfo const& info) noexcept;
 

--- a/potato/libeditor/include/potato/editor/property_grid.h
+++ b/potato/libeditor/include/potato/editor/property_grid.h
@@ -10,10 +10,9 @@
 
 namespace up {
     class AssetLoader;
+    class PropertyGrid;
     class UUID;
-} // namespace up
 
-namespace up::inline editor {
     class PropertyEditor {
     public:
         virtual ~PropertyEditor() = default;
@@ -24,7 +23,7 @@ namespace up::inline editor {
 
     class PropertyGrid {
     public:
-        void bindResourceLoader(AssetLoader* assetLoader) { _assetLoader = assetLoader; }
+        explicit PropertyGrid(AssetLoader& assetLoader) noexcept : _assetLoader(&assetLoader) { }
 
         bool beginItem(char const* label);
         void endItem();
@@ -66,4 +65,4 @@ namespace up::inline editor {
 
         AssetLoader* _assetLoader = nullptr;
     };
-} // namespace up::inline editor
+} // namespace up

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -341,11 +341,11 @@ namespace ImGui::inline Potato {
     void ApplyStyle() {
         auto& style = ImGui::GetStyle();
 
-        style.FrameRounding = 4.0f;
+        style.FrameRounding = 0.0f;
         style.GrabRounding = 4.0f;
         style.WindowRounding = 6.0f;
-        style.PopupRounding = 2.0f;
-        style.ChildRounding = 2.0f;
+        style.PopupRounding = 0.0f;
+        style.ChildRounding = 0.0f;
 
         style.WindowPadding = ImVec2(4.0f, 4.0f);
         style.FramePadding = ImVec2(4.0f, 4.0f);
@@ -362,7 +362,7 @@ namespace ImGui::inline Potato {
         colors[ImGuiCol_WindowBg] = ImVec4(0.11f, 0.15f, 0.17f, 1.00f);
         colors[ImGuiCol_ChildBg] = ImVec4(0.15f, 0.18f, 0.22f, 1.00f);
         colors[ImGuiCol_PopupBg] = ImVec4(0.08f, 0.08f, 0.08f, 0.94f);
-        colors[ImGuiCol_Border] = ImVec4(0.15f, 0.18f, 0.22f, 1.00f); // ImVec4(0.08f, 0.10f, 0.12f, 1.00f);
+        colors[ImGuiCol_Border] = ImVec4(0.10f, 0.14f, 0.16f, 1.00f); // ImVec4(0.08f, 0.10f, 0.12f, 1.00f);
         colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
         colors[ImGuiCol_FrameBg] = ImVec4(0.20f, 0.25f, 0.29f, 1.00f);
         colors[ImGuiCol_FrameBgHovered] = ImVec4(0.12f, 0.20f, 0.28f, 1.00f);

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -50,9 +50,6 @@ namespace ImGui::inline Potato {
     bool ToggleHeader(char const* label, char const* icon) noexcept {
         ImGuiID const openId = ImGui::GetID("open");
 
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-
         ImGuiStorage* const storage = ImGui::GetStateStorage();
         bool open = storage->GetBool(openId, true);
 

--- a/potato/libeditor/source/imgui_ext.cpp
+++ b/potato/libeditor/source/imgui_ext.cpp
@@ -47,6 +47,32 @@ namespace ImGui::inline Potato {
             nullptr);
     }
 
+    bool ToggleHeader(char const* label, char const* icon) noexcept {
+        ImGuiID const openId = ImGui::GetID("open");
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+
+        ImGuiStorage* const storage = ImGui::GetStateStorage();
+        bool open = storage->GetBool(openId, true);
+
+        char buf[256];
+        char const* selectLabel = label;
+        if (icon != nullptr) {
+            nanofmt::format_to(buf, "{} {}", icon, label);
+            selectLabel = buf;
+        }
+
+        ImGuiSelectableFlags const flags = ImGuiSelectableFlags_SpanAllColumns;
+
+        if (ImGui::Selectable(selectLabel, open, flags)) {
+            open = !open;
+            storage->SetBool(openId, open);
+        }
+
+        return open;
+    }
+
     bool IconButton(char const* label, char const* icon, ImVec2 size, ImGuiButtonFlags flags) {
         ImGuiWindow* window = GetCurrentWindow();
         if (window->SkipItems) {

--- a/potato/libeditor/source/property_grid.cpp
+++ b/potato/libeditor/source/property_grid.cpp
@@ -207,7 +207,6 @@ namespace up {
             explicit AssetRefPropertyEditor(AssetLoader& assetLoader) noexcept : _assetLoader(assetLoader) { }
 
             bool edit(PropertyInfo const& info) override {
-                ImGui::BeginGroup();
                 UP_GUARD(info.schema.primitive == reflex::SchemaPrimitive::AssetRef, false);
 
                 zstring_view assetType{};
@@ -251,8 +250,6 @@ namespace up {
                         edit = true;
                     }
                 }
-
-                ImGui::EndGroup();
 
                 return edit;
             }
@@ -364,9 +361,11 @@ namespace up {
     //    return edit;
     //}
 
-    bool PropertyGrid::beginTable() {
-        bool const open =
-            ImGui::BeginTable("##property_grid", 2, ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp);
+    bool PropertyGrid::beginTable(char const* label) {
+        bool const open = ImGui::BeginTable(
+            label != nullptr ? label : "##property_grid",
+            2,
+            ImGuiTableFlags_Resizable | ImGuiTableFlags_SizingStretchProp);
         ImGui::TableSetupColumn("Property", ImGuiTableColumnFlags_None, 0.4f);
         ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_None, 0.6f);
         return open;

--- a/potato/libeditor/source/property_grid.cpp
+++ b/potato/libeditor/source/property_grid.cpp
@@ -18,435 +18,437 @@
 #include <imgui.h>
 #include <numeric>
 
-bool up::editor::PropertyGrid::beginItem(char const* label) {
-    ImGuiID const openId = ImGui::GetID("open");
+namespace up {
+    bool PropertyGrid::beginItem(char const* label) {
+        ImGuiID const openId = ImGui::GetID("open");
 
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-
-    ImGuiStorage* const storage = ImGui::GetStateStorage();
-    bool open = storage->GetBool(openId, true);
-
-    ImGuiSelectableFlags const flags = ImGuiSelectableFlags_SpanAllColumns;
-
-    if (ImGui::Selectable(label, open, flags)) {
-        open = !open;
-        storage->SetBool(openId, open);
-    }
-
-    return open;
-}
-
-void up::editor::PropertyGrid::endItem() { }
-
-bool up::editor::PropertyGrid::_editField(
-    reflex::SchemaField const& field,
-    reflex::Schema const& schema,
-    void* object) {
-    ImGui::PushID(object);
-
-    bool edit = false;
-
-    switch (schema.primitive) {
-        case reflex::SchemaPrimitive::Int16:
-            edit = _editIntegerField(field, *static_cast<int16*>(object));
-            break;
-        case reflex::SchemaPrimitive::Int32:
-            edit = _editIntegerField(field, *static_cast<int32*>(object));
-            break;
-        case reflex::SchemaPrimitive::Int64:
-            edit = _editIntegerField(field, *static_cast<int64*>(object));
-            break;
-        case reflex::SchemaPrimitive::Float:
-            edit = _editFloatField(field, *static_cast<float*>(object));
-            break;
-        case reflex::SchemaPrimitive::Double:
-            edit = _editFloatField(field, *static_cast<double*>(object));
-            break;
-        case reflex::SchemaPrimitive::Vec3:
-            edit = _editVec3Field(field, *static_cast<glm::vec3*>(object));
-            break;
-        case reflex::SchemaPrimitive::Mat4x4:
-            edit = _editMat4x4Field(field, *static_cast<glm::mat4x4*>(object));
-            break;
-        case reflex::SchemaPrimitive::Quat:
-            edit = _editQuatField(field, *static_cast<glm::quat*>(object));
-            break;
-        case reflex::SchemaPrimitive::String:
-            edit = _editStringField(field, *static_cast<string*>(object));
-            break;
-        case reflex::SchemaPrimitive::Pointer:
-            if (schema.operations->pointerMutableDeref != nullptr) {
-                if (void* pointee = schema.operations->pointerMutableDeref(object)) {
-                    edit = _editField(field, *schema.elementType, pointee);
-                    break;
-                }
-            }
-            edit = false;
-            break;
-        case reflex::SchemaPrimitive::Array:
-            edit = _editArrayField(field, schema, object);
-            break;
-        case reflex::SchemaPrimitive::Object:
-            edit = _drawObjectEditor(schema, object);
-            break;
-        case reflex::SchemaPrimitive::AssetRef:
-            edit = _editAssetField(field, schema, object);
-            break;
-        case reflex::SchemaPrimitive::Uuid:
-            edit = _editUuidField(field, *static_cast<UUID*>(object));
-            break;
-        default:
-            ImGui::Text("Unsupported primitive type for schema `%s`", schema.name.c_str());
-            break;
-    }
-
-    ImGui::PopID();
-
-    return edit;
-}
-
-bool up::editor::PropertyGrid::_drawObjectEditor(reflex::Schema const& schema, void* object) {
-    ImGui::TextDisabled("%s", schema.name.c_str());
-
-    return _editProperties(schema, object);
-}
-
-bool up::editor::PropertyGrid::_editArrayField(
-    reflex::SchemaField const& field,
-    reflex::Schema const& schema,
-    void* object) {
-    if (schema.operations == nullptr) {
-        ImGui::TextDisabled("Unsupported type");
-        return false;
-    }
-
-    if (schema.operations->arrayGetSize == nullptr || schema.operations->arrayElementAt == nullptr) {
-        ImGui::TextDisabled("Unsupported type");
-        return false;
-    }
-
-    size_t const size = schema.operations->arrayGetSize(object);
-
-    ImGui::Text("%d items :: %s", static_cast<int>(size), schema.name.c_str());
-
-    size_t eraseIndex = size;
-    size_t swapFirst = size;
-    size_t swapSecond = size;
-
-    bool edit = false;
-
-    for (size_t index = 0; index != size; ++index) {
-        void* element = schema.operations->arrayMutableElementAt(object, index);
-
-        ImGui::PushID(static_cast<int>(index));
         ImGui::TableNextRow();
-
         ImGui::TableSetColumnIndex(0);
-        ImGui::AlignTextToFramePadding();
-        ImGui::BeginGroup();
 
-        float const rowY = ImGui::GetCursorPosY();
+        ImGuiStorage* const storage = ImGui::GetStateStorage();
+        bool open = storage->GetBool(openId, true);
 
-        // Row for handling drag-n-drop reordering of items
-        if (schema.operations->arraySwapIndices != nullptr) {
-            bool selected = false;
-            ImGui::Selectable("##row", &selected, ImGuiSelectableFlags_AllowItemOverlap);
+        ImGuiSelectableFlags const flags = ImGuiSelectableFlags_SpanAllColumns;
 
-            if (ImGui::BeginDragDropTarget()) {
-                if (ImGuiPayload const* payload = ImGui::AcceptDragDropPayload("reorder"); payload != nullptr) {
-                    swapFirst = *static_cast<size_t const*>(payload->Data);
-                    swapSecond = index;
-                }
-                ImGui::EndDragDropTarget();
-            }
-
-            if (ImGui::BeginDragDropSource(
-                    ImGuiDragDropFlags_SourceAutoExpirePayload | ImGuiDragDropFlags_SourceNoPreviewTooltip |
-                    ImGuiDragDropFlags_SourceNoDisableHover)) {
-                ImGui::SetDragDropPayload("reorder", &index, sizeof(index));
-                ImGui::EndDragDropSource();
-            }
+        if (ImGui::Selectable(label, open, flags)) {
+            open = !open;
+            storage->SetBool(openId, open);
         }
 
-        // Icon for deleting a row
-        if (schema.operations->arrayEraseAt != nullptr) {
+        return open;
+    }
+
+    void PropertyGrid::endItem() { }
+
+    bool PropertyGrid::_editField(
+        reflex::SchemaField const& field,
+        reflex::Schema const& schema,
+        void* object) {
+        ImGui::PushID(object);
+
+        bool edit = false;
+
+        switch (schema.primitive) {
+            case reflex::SchemaPrimitive::Int16:
+                edit = _editIntegerField(field, *static_cast<int16*>(object));
+                break;
+            case reflex::SchemaPrimitive::Int32:
+                edit = _editIntegerField(field, *static_cast<int32*>(object));
+                break;
+            case reflex::SchemaPrimitive::Int64:
+                edit = _editIntegerField(field, *static_cast<int64*>(object));
+                break;
+            case reflex::SchemaPrimitive::Float:
+                edit = _editFloatField(field, *static_cast<float*>(object));
+                break;
+            case reflex::SchemaPrimitive::Double:
+                edit = _editFloatField(field, *static_cast<double*>(object));
+                break;
+            case reflex::SchemaPrimitive::Vec3:
+                edit = _editVec3Field(field, *static_cast<glm::vec3*>(object));
+                break;
+            case reflex::SchemaPrimitive::Mat4x4:
+                edit = _editMat4x4Field(field, *static_cast<glm::mat4x4*>(object));
+                break;
+            case reflex::SchemaPrimitive::Quat:
+                edit = _editQuatField(field, *static_cast<glm::quat*>(object));
+                break;
+            case reflex::SchemaPrimitive::String:
+                edit = _editStringField(field, *static_cast<string*>(object));
+                break;
+            case reflex::SchemaPrimitive::Pointer:
+                if (schema.operations->pointerMutableDeref != nullptr) {
+                    if (void* pointee = schema.operations->pointerMutableDeref(object)) {
+                        edit = _editField(field, *schema.elementType, pointee);
+                        break;
+                    }
+                }
+                edit = false;
+                break;
+            case reflex::SchemaPrimitive::Array:
+                edit = _editArrayField(field, schema, object);
+                break;
+            case reflex::SchemaPrimitive::Object:
+                edit = _drawObjectEditor(schema, object);
+                break;
+            case reflex::SchemaPrimitive::AssetRef:
+                edit = _editAssetField(field, schema, object);
+                break;
+            case reflex::SchemaPrimitive::Uuid:
+                edit = _editUuidField(field, *static_cast<UUID*>(object));
+                break;
+            default:
+                ImGui::Text("Unsupported primitive type for schema `%s`", schema.name.c_str());
+                break;
+        }
+
+        ImGui::PopID();
+
+        return edit;
+    }
+
+    bool PropertyGrid::_drawObjectEditor(reflex::Schema const& schema, void* object) {
+        ImGui::TextDisabled("%s", schema.name.c_str());
+
+        return _editProperties(schema, object);
+    }
+
+    bool PropertyGrid::_editArrayField(
+        reflex::SchemaField const& field,
+        reflex::Schema const& schema,
+        void* object) {
+        if (schema.operations == nullptr) {
+            ImGui::TextDisabled("Unsupported type");
+            return false;
+        }
+
+        if (schema.operations->arrayGetSize == nullptr || schema.operations->arrayElementAt == nullptr) {
+            ImGui::TextDisabled("Unsupported type");
+            return false;
+        }
+
+        size_t const size = schema.operations->arrayGetSize(object);
+
+        ImGui::Text("%d items :: %s", static_cast<int>(size), schema.name.c_str());
+
+        size_t eraseIndex = size;
+        size_t swapFirst = size;
+        size_t swapSecond = size;
+
+        bool edit = false;
+
+        for (size_t index = 0; index != size; ++index) {
+            void* element = schema.operations->arrayMutableElementAt(object, index);
+
+            ImGui::PushID(static_cast<int>(index));
+            ImGui::TableNextRow();
+
+            ImGui::TableSetColumnIndex(0);
+            ImGui::AlignTextToFramePadding();
+            ImGui::BeginGroup();
+
+            float const rowY = ImGui::GetCursorPosY();
+
+            // Row for handling drag-n-drop reordering of items
+            if (schema.operations->arraySwapIndices != nullptr) {
+                bool selected = false;
+                ImGui::Selectable("##row", &selected, ImGuiSelectableFlags_AllowItemOverlap);
+
+                if (ImGui::BeginDragDropTarget()) {
+                    if (ImGuiPayload const* payload = ImGui::AcceptDragDropPayload("reorder"); payload != nullptr) {
+                        swapFirst = *static_cast<size_t const*>(payload->Data);
+                        swapSecond = index;
+                    }
+                    ImGui::EndDragDropTarget();
+                }
+
+                if (ImGui::BeginDragDropSource(
+                        ImGuiDragDropFlags_SourceAutoExpirePayload | ImGuiDragDropFlags_SourceNoPreviewTooltip |
+                        ImGuiDragDropFlags_SourceNoDisableHover)) {
+                    ImGui::SetDragDropPayload("reorder", &index, sizeof(index));
+                    ImGui::EndDragDropSource();
+                }
+            }
+
+            // Icon for deleting a row
+            if (schema.operations->arrayEraseAt != nullptr) {
+                float const availWidth = ImGui::GetContentRegionAvail().x;
+                float const buttonWidth = ImGui::GetFontSize() + ImGui::GetStyle().FramePadding.x * 2.f;
+                float const adjustWidth = availWidth - buttonWidth;
+                ImGui::SetCursorPos({ImGui::GetCursorPosX() + adjustWidth, rowY});
+                if (ImGui::IconButton("##remove", ICON_FA_TRASH)) {
+                    eraseIndex = index;
+                }
+            }
+
+            ImGui::EndGroup();
+
+            ImGui::TableSetColumnIndex(1);
+            ImGui::AlignTextToFramePadding();
+            edit |= _editField(field, *schema.elementType, element);
+            ImGui::PopID();
+        }
+
+        if (schema.operations->arrayInsertAt != nullptr) {
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::AlignTextToFramePadding();
             float const availWidth = ImGui::GetContentRegionAvail().x;
             float const buttonWidth = ImGui::GetFontSize() + ImGui::GetStyle().FramePadding.x * 2.f;
             float const adjustWidth = availWidth - buttonWidth;
-            ImGui::SetCursorPos({ImGui::GetCursorPosX() + adjustWidth, rowY});
-            if (ImGui::IconButton("##remove", ICON_FA_TRASH)) {
-                eraseIndex = index;
+            ImGui::SetCursorPosX(ImGui::GetCursorPosX() + adjustWidth);
+            if (ImGui::IconButton("##add", ICON_FA_PLUS)) {
+                schema.operations->arrayInsertAt(object, size);
+                edit = true;
+            }
+
+            ImGui::TableSetColumnIndex(1);
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextDisabled("Add new row");
+        }
+
+        if (eraseIndex < size) {
+            schema.operations->arrayEraseAt(object, eraseIndex);
+            edit = true;
+        }
+        else if (swapFirst < size) {
+            schema.operations->arraySwapIndices(object, swapFirst, swapSecond);
+            edit = true;
+        }
+
+        return edit;
+    }
+
+    bool PropertyGrid::_beginProperty(reflex::SchemaField const& field, void* object) {
+        if (queryAnnotation<schema::Hidden>(field) != nullptr) {
+            return false;
+        }
+
+        auto const* const displayNameAnnotation = queryAnnotation<schema::DisplayName>(field);
+        zstring_view const displayName = displayNameAnnotation != nullptr && !displayNameAnnotation->name.empty()
+            ? displayNameAnnotation->name
+            : field.name;
+
+        ImGuiTreeNodeFlags flags =
+            ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_SpanAvailWidth;
+        bool const expandable =
+            (field.schema->primitive == reflex::SchemaPrimitive::Object ||
+             field.schema->primitive == reflex::SchemaPrimitive::Mat4x4);
+        if (!expandable) {
+            flags |= ImGuiTreeNodeFlags_Leaf;
+        }
+
+        ImGui::TableNextRow();
+        ImGui::TableSetColumnIndex(0);
+        ImGui::AlignTextToFramePadding();
+
+        void* const member = static_cast<char*>(object) + field.offset;
+
+        ImGui::PushID(member);
+        bool const open = ImGui::TreeNodeEx(displayName.c_str(), flags);
+        ImGui::PopID();
+
+        auto const* const tooltipAnnotation = queryAnnotation<schema::Tooltip>(field);
+        if (tooltipAnnotation != nullptr && ImGui::IsItemHovered()) {
+            ImGui::BeginTooltip();
+            ImGui::Text("%s", tooltipAnnotation->text.c_str());
+            ImGui::EndTooltip();
+        }
+
+        if (open) {
+            ImGui::TreePush(member);
+        }
+        return open;
+    }
+
+    void PropertyGrid::_endProperty() { ImGui::TreePop(); }
+
+    bool PropertyGrid::_editProperties(reflex::Schema const& schema, void* object) {
+        UP_GUARD(schema.primitive == reflex::SchemaPrimitive::Object, false);
+
+        bool edits = false;
+
+        for (reflex::SchemaField const& field : schema.fields) {
+            if (field.schema->primitive == reflex::SchemaPrimitive::Object &&
+                queryAnnotation<schema::Flatten>(field) != nullptr) {
+                void* const member = static_cast<char*>(object) + field.offset;
+                edits |= _editProperties(*field.schema, member);
+                continue;
+            }
+
+            if (_beginProperty(field, object)) {
+                edits |= _editProperty(field, object);
+                _endProperty();
+            }
+        }
+
+        return edits;
+    }
+
+    bool PropertyGrid::_editProperty(reflex::SchemaField const& field, void* object) {
+        void* const member = static_cast<char*>(object) + field.offset;
+
+        ImGui::TableSetColumnIndex(1);
+        ImGui::AlignTextToFramePadding();
+
+        return _editField(field, *field.schema, member);
+    }
+
+    bool PropertyGrid::_editIntegerField(reflex::SchemaField const& field, int& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+
+        auto const* const rangeAnnotation = queryAnnotation<up::schema::IntRange>(field);
+        if (rangeAnnotation != nullptr) {
+            return ImGui::SliderInt("##int", &value, rangeAnnotation->min, rangeAnnotation->max);
+        }
+
+        return ImGui::InputInt("##int", &value);
+    }
+
+    bool PropertyGrid::_editFloatField(reflex::SchemaField const& field, float& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+
+        auto const* const rangeAnnotation = queryAnnotation<up::schema::FloatRange>(field);
+        if (rangeAnnotation != nullptr) {
+            return ImGui::SliderFloat("##float", &value, rangeAnnotation->min, rangeAnnotation->max);
+        }
+
+        return ImGui::InputFloat("##float", &value);
+    }
+
+    bool PropertyGrid::_editFloatField(
+        [[maybe_unused]] reflex::SchemaField const& field,
+        double& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+
+        return ImGui::InputDouble("##double", &value);
+    }
+
+    bool PropertyGrid::_editVec3Field(
+        [[maybe_unused]] reflex::SchemaField const& field,
+        glm::vec3& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+        return ImGui::InputVec3("##vec3", value);
+    }
+
+    bool PropertyGrid::_editMat4x4Field(
+        [[maybe_unused]] reflex::SchemaField const& field,
+        glm::mat4x4& value) noexcept {
+        bool edit = false;
+        ImGui::SetNextItemWidth(-1.f);
+        edit |= ImGui::InputFloat4("##a", &value[0].x);
+        ImGui::SetNextItemWidth(-1.f);
+        edit |= ImGui::InputFloat4("##b", &value[1].x);
+        ImGui::SetNextItemWidth(-1.f);
+        edit |= ImGui::InputFloat4("##c", &value[2].x);
+        ImGui::SetNextItemWidth(-1.f);
+        edit |= ImGui::InputFloat4("##d", &value[3].x);
+        return edit;
+    }
+
+    bool PropertyGrid::_editQuatField(
+        [[maybe_unused]] reflex::SchemaField const& field,
+        glm::quat& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+        return ImGui::InputQuat("##quat", value);
+    }
+
+    bool PropertyGrid::_editStringField(
+        [[maybe_unused]] reflex::SchemaField const& field,
+        string& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+
+        // FIXME:
+        // up::string is an immutable string type, which isn't easy to make editable
+        // in a well-performing way. we ideally want to know when a string is being
+        // edited, make a temporary copy into a cheaply-resizable buffer, then post-
+        // edit copy that back into a new up::string. For now... just this.
+        char buffer[512];
+        nanofmt::format_to(buffer, "{}", value);
+
+        if (ImGui::InputText("##string", buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue)) {
+            value = string(buffer);
+            return true;
+        }
+
+        return false;
+    }
+
+    bool PropertyGrid::_editAssetField(
+        reflex::SchemaField const& field,
+        reflex::Schema const& schema,
+        void* object) {
+        ImGui::BeginGroup();
+        UP_GUARD(schema.primitive == reflex::SchemaPrimitive::AssetRef, false);
+
+        zstring_view assetType{};
+        if (auto const* const assetTypeAnno = queryAnnotation<schema::AssetType>(schema); assetTypeAnno != nullptr) {
+            assetType = assetTypeAnno->assetType;
+        }
+
+        auto* const handle = static_cast<UntypedAssetHandle*>(object);
+        AssetId const assetId = handle->assetId();
+        zstring_view displayName = "<empty>"_zsv;
+
+        if (handle->isSet()) {
+            displayName = _assetLoader->debugName(assetId);
+        }
+
+        bool edit = false;
+
+        ImGui::Text("%s", displayName.c_str());
+        ImGui::SameLine();
+        if (ImGui::IconButton("##clear", ICON_FA_TRASH) && schema.operations->pointerAssign != nullptr) {
+            schema.operations->pointerAssign(object, nullptr);
+            edit = true;
+        }
+        ImGui::SameLine();
+
+        char browserId[32] = {
+            0,
+        };
+        nanofmt::format_to(browserId, "##assets{}", ImGui::GetID("popup"));
+
+        if (ImGui::IconButton("##select", ICON_FA_FOLDER)) {
+            ImGui::OpenPopup(browserId);
+        }
+
+        if (_assetLoader != nullptr && schema.operations != nullptr && schema.operations->pointerAssign != nullptr) {
+            AssetId targetAssetId = assetId;
+            if (up::assetBrowserPopup(browserId, targetAssetId, assetType, *_assetLoader) && targetAssetId != assetId) {
+                *handle = _assetLoader->loadAssetSync(targetAssetId, assetType);
+                edit = true;
             }
         }
 
         ImGui::EndGroup();
 
-        ImGui::TableSetColumnIndex(1);
-        ImGui::AlignTextToFramePadding();
-        edit |= _editField(field, *schema.elementType, element);
-        ImGui::PopID();
+        return edit;
     }
 
-    if (schema.operations->arrayInsertAt != nullptr) {
-        ImGui::TableNextRow();
-        ImGui::TableSetColumnIndex(0);
-        ImGui::AlignTextToFramePadding();
-        float const availWidth = ImGui::GetContentRegionAvail().x;
-        float const buttonWidth = ImGui::GetFontSize() + ImGui::GetStyle().FramePadding.x * 2.f;
-        float const adjustWidth = availWidth - buttonWidth;
-        ImGui::SetCursorPosX(ImGui::GetCursorPosX() + adjustWidth);
-        if (ImGui::IconButton("##add", ICON_FA_PLUS)) {
-            schema.operations->arrayInsertAt(object, size);
-            edit = true;
+    bool PropertyGrid::_editUuidField(
+        [[maybe_unused]] reflex::SchemaField const& field,
+        UUID& value) noexcept {
+        ImGui::SetNextItemWidth(-1.f);
+
+        // FIXME:
+        // up::string is an immutable string type, which isn't easy to make editable
+        // in a well-performing way. we ideally want to know when a string is being
+        // edited, make a temporary copy into a cheaply-resizable buffer, then post-
+        // edit copy that back into a new up::string. For now... just this.
+        char buffer[UUID::strLength];
+        nanofmt::format_to(buffer, "{}", value);
+
+        if (ImGui::InputText(
+                "##uuid",
+                buffer,
+                sizeof(buffer),
+                ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_CharsHexadecimal |
+                    ImGuiInputTextFlags_CharsDecimal /* for dash */)) {
+            value = UUID::fromString(buffer);
+            return true;
         }
 
-        ImGui::TableSetColumnIndex(1);
-        ImGui::AlignTextToFramePadding();
-        ImGui::TextDisabled("Add new row");
-    }
-
-    if (eraseIndex < size) {
-        schema.operations->arrayEraseAt(object, eraseIndex);
-        edit = true;
-    }
-    else if (swapFirst < size) {
-        schema.operations->arraySwapIndices(object, swapFirst, swapSecond);
-        edit = true;
-    }
-
-    return edit;
-}
-
-bool up::editor::PropertyGrid::_beginProperty(reflex::SchemaField const& field, void* object) {
-    if (queryAnnotation<schema::Hidden>(field) != nullptr) {
         return false;
     }
-
-    auto const* const displayNameAnnotation = queryAnnotation<schema::DisplayName>(field);
-    zstring_view const displayName = displayNameAnnotation != nullptr && !displayNameAnnotation->name.empty()
-        ? displayNameAnnotation->name
-        : field.name;
-
-    ImGuiTreeNodeFlags flags =
-        ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_SpanAvailWidth;
-    bool const expandable =
-        (field.schema->primitive == reflex::SchemaPrimitive::Object ||
-         field.schema->primitive == reflex::SchemaPrimitive::Mat4x4);
-    if (!expandable) {
-        flags |= ImGuiTreeNodeFlags_Leaf;
-    }
-
-    ImGui::TableNextRow();
-    ImGui::TableSetColumnIndex(0);
-    ImGui::AlignTextToFramePadding();
-
-    void* const member = static_cast<char*>(object) + field.offset;
-
-    ImGui::PushID(member);
-    bool const open = ImGui::TreeNodeEx(displayName.c_str(), flags);
-    ImGui::PopID();
-
-    auto const* const tooltipAnnotation = queryAnnotation<schema::Tooltip>(field);
-    if (tooltipAnnotation != nullptr && ImGui::IsItemHovered()) {
-        ImGui::BeginTooltip();
-        ImGui::Text("%s", tooltipAnnotation->text.c_str());
-        ImGui::EndTooltip();
-    }
-
-    if (open) {
-        ImGui::TreePush(member);
-    }
-    return open;
-}
-
-void up::editor::PropertyGrid::_endProperty() {
-    ImGui::TreePop();
-}
-
-bool up::editor::PropertyGrid::_editProperties(reflex::Schema const& schema, void* object) {
-    UP_GUARD(schema.primitive == reflex::SchemaPrimitive::Object, false);
-
-    bool edits = false;
-
-    for (reflex::SchemaField const& field : schema.fields) {
-        if (field.schema->primitive == reflex::SchemaPrimitive::Object &&
-            queryAnnotation<schema::Flatten>(field) != nullptr) {
-            void* const member = static_cast<char*>(object) + field.offset;
-            edits |= _editProperties(*field.schema, member);
-            continue;
-        }
-
-        if (_beginProperty(field, object)) {
-            edits |= _editProperty(field, object);
-            _endProperty();
-        }
-    }
-
-    return edits;
-}
-
-bool up::editor::PropertyGrid::_editProperty(reflex::SchemaField const& field, void* object) {
-    void* const member = static_cast<char*>(object) + field.offset;
-
-    ImGui::TableSetColumnIndex(1);
-    ImGui::AlignTextToFramePadding();
-
-    return _editField(field, *field.schema, member);
-}
-
-bool up::editor::PropertyGrid::_editIntegerField(reflex::SchemaField const& field, int& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-
-    auto const* const rangeAnnotation = queryAnnotation<up::schema::IntRange>(field);
-    if (rangeAnnotation != nullptr) {
-        return ImGui::SliderInt("##int", &value, rangeAnnotation->min, rangeAnnotation->max);
-    }
-
-    return ImGui::InputInt("##int", &value);
-}
-
-bool up::editor::PropertyGrid::_editFloatField(reflex::SchemaField const& field, float& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-
-    auto const* const rangeAnnotation = queryAnnotation<up::schema::FloatRange>(field);
-    if (rangeAnnotation != nullptr) {
-        return ImGui::SliderFloat("##float", &value, rangeAnnotation->min, rangeAnnotation->max);
-    }
-
-    return ImGui::InputFloat("##float", &value);
-}
-
-bool up::editor::PropertyGrid::_editFloatField(
-    [[maybe_unused]] reflex::SchemaField const& field,
-    double& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-
-    return ImGui::InputDouble("##double", &value);
-}
-
-bool up::editor::PropertyGrid::_editVec3Field(
-    [[maybe_unused]] reflex::SchemaField const& field,
-    glm::vec3& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-    return ImGui::InputVec3("##vec3", value);
-}
-
-bool up::editor::PropertyGrid::_editMat4x4Field(
-    [[maybe_unused]] reflex::SchemaField const& field,
-    glm::mat4x4& value) noexcept {
-    bool edit = false;
-    ImGui::SetNextItemWidth(-1.f);
-    edit |= ImGui::InputFloat4("##a", &value[0].x);
-    ImGui::SetNextItemWidth(-1.f);
-    edit |= ImGui::InputFloat4("##b", &value[1].x);
-    ImGui::SetNextItemWidth(-1.f);
-    edit |= ImGui::InputFloat4("##c", &value[2].x);
-    ImGui::SetNextItemWidth(-1.f);
-    edit |= ImGui::InputFloat4("##d", &value[3].x);
-    return edit;
-}
-
-bool up::editor::PropertyGrid::_editQuatField(
-    [[maybe_unused]] reflex::SchemaField const& field,
-    glm::quat& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-    return ImGui::InputQuat("##quat", value);
-}
-
-bool up::editor::PropertyGrid::_editStringField(
-    [[maybe_unused]] reflex::SchemaField const& field,
-    string& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-
-    // FIXME:
-    // up::string is an immutable string type, which isn't easy to make editable
-    // in a well-performing way. we ideally want to know when a string is being
-    // edited, make a temporary copy into a cheaply-resizable buffer, then post-
-    // edit copy that back into a new up::string. For now... just this.
-    char buffer[512];
-    nanofmt::format_to(buffer, "{}", value);
-
-    if (ImGui::InputText("##string", buffer, sizeof(buffer), ImGuiInputTextFlags_EnterReturnsTrue)) {
-        value = string(buffer);
-        return true;
-    }
-
-    return false;
-}
-
-bool up::editor::PropertyGrid::_editAssetField(
-    reflex::SchemaField const& field,
-    reflex::Schema const& schema,
-    void* object) {
-    ImGui::BeginGroup();
-    UP_GUARD(schema.primitive == reflex::SchemaPrimitive::AssetRef, false);
-
-    zstring_view assetType{};
-    if (auto const* const assetTypeAnno = queryAnnotation<schema::AssetType>(schema); assetTypeAnno != nullptr) {
-        assetType = assetTypeAnno->assetType;
-    }
-
-    auto* const handle = static_cast<UntypedAssetHandle*>(object);
-    AssetId const assetId = handle->assetId();
-    zstring_view displayName = "<empty>"_zsv;
-
-    if (handle->isSet()) {
-        displayName = _assetLoader->debugName(assetId);
-    }
-
-    bool edit = false;
-
-    ImGui::Text("%s", displayName.c_str());
-    ImGui::SameLine();
-    if (ImGui::IconButton("##clear", ICON_FA_TRASH) && schema.operations->pointerAssign != nullptr) {
-        schema.operations->pointerAssign(object, nullptr);
-        edit = true;
-    }
-    ImGui::SameLine();
-
-    char browserId[32] = {
-        0,
-    };
-    nanofmt::format_to(browserId, "##assets{}", ImGui::GetID("popup"));
-
-    if (ImGui::IconButton("##select", ICON_FA_FOLDER)) {
-        ImGui::OpenPopup(browserId);
-    }
-
-    if (_assetLoader != nullptr && schema.operations != nullptr && schema.operations->pointerAssign != nullptr) {
-        AssetId targetAssetId = assetId;
-        if (up::assetBrowserPopup(browserId, targetAssetId, assetType, *_assetLoader) && targetAssetId != assetId) {
-            *handle = _assetLoader->loadAssetSync(targetAssetId, assetType);
-            edit = true;
-        }
-    }
-
-    ImGui::EndGroup();
-
-    return edit;
-}
-
-bool up::editor::PropertyGrid::_editUuidField([[maybe_unused]] reflex::SchemaField const& field, UUID& value) noexcept {
-    ImGui::SetNextItemWidth(-1.f);
-
-    // FIXME:
-    // up::string is an immutable string type, which isn't easy to make editable
-    // in a well-performing way. we ideally want to know when a string is being
-    // edited, make a temporary copy into a cheaply-resizable buffer, then post-
-    // edit copy that back into a new up::string. For now... just this.
-    char buffer[UUID::strLength];
-    nanofmt::format_to(buffer, "{}", value);
-
-    if (ImGui::InputText(
-            "##uuid",
-            buffer,
-            sizeof(buffer),
-            ImGuiInputTextFlags_EnterReturnsTrue | ImGuiInputTextFlags_CharsHexadecimal |
-                ImGuiInputTextFlags_CharsDecimal /* for dash */)) {
-        value = UUID::fromString(buffer);
-        return true;
-    }
-
-    return false;
-}
+} // namespace up

--- a/potato/libeditor/source/property_grid.cpp
+++ b/potato/libeditor/source/property_grid.cpp
@@ -394,13 +394,13 @@ namespace up {
 
     PropertyGrid::PropertyGrid(AssetLoader& assetLoader) noexcept {
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<BoolPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Bool, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<IntegerPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Int8, index);
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::UInt8, index);
@@ -413,56 +413,56 @@ namespace up {
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<FloatPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Float, index);
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Double, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<Vec3PropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Vec3, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<QuaternionPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Quat, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<StringPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::String, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<ArrayPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Array, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<ObjectPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Object, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<PointerPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Pointer, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<UuidPropertyEditor>());
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::Uuid, index);
         }
 
         {
-            uint32 const index = static_cast<uint32>(_propertyEditors.size());
+            auto const index = static_cast<uint32>(_propertyEditors.size());
             _propertyEditors.push_back(new_box<AssetRefPropertyEditor>(assetLoader));
             _primitiveEditorMap.insert(reflex::SchemaPrimitive::AssetRef, index);
         }

--- a/potato/libreflex/include/potato/reflex/schema.h
+++ b/potato/libreflex/include/potato/reflex/schema.h
@@ -63,10 +63,8 @@ namespace up::reflex {
         using ArrayGetSize = size_t (*)(void const* arr);
         using ArrayElementAt = void const* (*)(void const* arr, size_t index);
         using ArrayMutableElementAt = void* (*)(void* arr, size_t index);
-        using ArraySwapIndices = void (*)(void* arr, size_t first, size_t second);
         using ArrayMoveTo = void (*)(void* arr, size_t to, size_t from);
         using ArrayEraseAt = void (*)(void* arr, size_t index);
-        using ArrayInsertAt = void (*)(void* arr, size_t index);
         using ArrayResize = void (*)(void* arr, size_t size);
 
         using PointerDeref = void const* (*)(void const* ptr);
@@ -76,10 +74,8 @@ namespace up::reflex {
         ArrayGetSize arrayGetSize = nullptr;
         ArrayElementAt arrayElementAt = nullptr;
         ArrayMutableElementAt arrayMutableElementAt = nullptr;
-        ArraySwapIndices arraySwapIndices = nullptr;
         ArrayMoveTo arrayMoveTo = nullptr;
         ArrayEraseAt arrayEraseAt = nullptr;
-        ArrayInsertAt arrayInsertAt = nullptr;
         ArrayResize arrayResize = nullptr;
 
         PointerDeref pointerDeref = nullptr;
@@ -229,13 +225,9 @@ namespace up::reflex {
                     auto& arr = *static_cast<Type*>(array);
                     return arr.data() + index;
                 },
-                .arraySwapIndices =
-                    [](void* array, size_t first, size_t second) noexcept {
                 .arrayMoveTo =
                     [](void* array, size_t to, size_t from) noexcept {
                         auto& arr = *static_cast<Type*>(array);
-                        using std::swap;
-                        swap(arr[first], arr[second]);
                         int const step = to > from ? +1 : -1;
                         while (from != to) {
                             using std::swap;
@@ -248,11 +240,6 @@ namespace up::reflex {
                     [](void* array, size_t index) {
                         auto& arr = *static_cast<Type*>(array);
                         arr.erase(arr.begin() + index);
-                    },
-                .arrayInsertAt =
-                    [](void* array, size_t index) {
-                        auto& arr = *static_cast<Type*>(array);
-                        arr.insert(arr.begin() + index, {});
                     },
                 .arrayResize =
                     [](void* array, size_t size) {

--- a/potato/libreflex/include/potato/reflex/schema.h
+++ b/potato/libreflex/include/potato/reflex/schema.h
@@ -43,7 +43,6 @@ namespace up::reflex {
         UInt64,
         Enum,
         Vec3,
-        Mat4x4,
         Quat,
         Float,
         Double,

--- a/potato/libreflex/include/potato/reflex/schema.h
+++ b/potato/libreflex/include/potato/reflex/schema.h
@@ -124,8 +124,7 @@ namespace up::reflex {
     struct SchemaHolder;
 
     template <typename T>
-    concept schema_glm_type =
-        std::is_same_v<T, glm::vec3> || std::is_same_v<T, glm::mat4x4> || std::is_same_v<T, glm::quat>;
+    concept schema_glm_type = std::is_same_v<T, glm::vec3> || std::is_same_v<T, glm::quat>;
     template <typename T>
     concept schema_primitive = std::is_scalar_v<T> || std::is_same_v<T, string> || schema_glm_type<T> || is_vector_v<T>;
     template <typename T>
@@ -187,10 +186,6 @@ namespace up::reflex {
         }
         else if constexpr (std::is_same_v<Type, glm::vec3>) {
             static constexpr Schema schema{.name = "vec3"_zsv, .primitive = SchemaPrimitive::Vec3};
-            return schema;
-        }
-        else if constexpr (std::is_same_v<Type, glm::mat4x4>) {
-            static constexpr Schema schema{.name = "mat4x4"_zsv, .primitive = SchemaPrimitive::Mat4x4};
             return schema;
         }
         else if constexpr (std::is_same_v<Type, glm::quat>) {

--- a/potato/libreflex/include/potato/reflex/schema.h
+++ b/potato/libreflex/include/potato/reflex/schema.h
@@ -64,6 +64,7 @@ namespace up::reflex {
         using ArrayElementAt = void const* (*)(void const* arr, size_t index);
         using ArrayMutableElementAt = void* (*)(void* arr, size_t index);
         using ArraySwapIndices = void (*)(void* arr, size_t first, size_t second);
+        using ArrayMoveTo = void (*)(void* arr, size_t to, size_t from);
         using ArrayEraseAt = void (*)(void* arr, size_t index);
         using ArrayInsertAt = void (*)(void* arr, size_t index);
         using ArrayResize = void (*)(void* arr, size_t size);
@@ -76,6 +77,7 @@ namespace up::reflex {
         ArrayElementAt arrayElementAt = nullptr;
         ArrayMutableElementAt arrayMutableElementAt = nullptr;
         ArraySwapIndices arraySwapIndices = nullptr;
+        ArrayMoveTo arrayMoveTo = nullptr;
         ArrayEraseAt arrayEraseAt = nullptr;
         ArrayInsertAt arrayInsertAt = nullptr;
         ArrayResize arrayResize = nullptr;
@@ -229,9 +231,18 @@ namespace up::reflex {
                 },
                 .arraySwapIndices =
                     [](void* array, size_t first, size_t second) noexcept {
+                .arrayMoveTo =
+                    [](void* array, size_t to, size_t from) noexcept {
                         auto& arr = *static_cast<Type*>(array);
                         using std::swap;
                         swap(arr[first], arr[second]);
+                        int const step = to > from ? +1 : -1;
+                        while (from != to) {
+                            using std::swap;
+                            size_t const next = from + step;
+                            swap(arr[from], arr[next]);
+                            from = next;
+                        }
                     },
                 .arrayEraseAt =
                     [](void* array, size_t index) {

--- a/potato/libreflex/source/serialize.cpp
+++ b/potato/libreflex/source/serialize.cpp
@@ -160,7 +160,6 @@ bool up::reflex::_detail::encodeValue(nlohmann::json& json, Schema const& schema
             json.push_back(static_cast<glm::vec3 const*>(obj)->y);
             json.push_back(static_cast<glm::vec3 const*>(obj)->z);
             return true;
-        case SchemaPrimitive::Mat4x4:
         case SchemaPrimitive::Quat:
             return false;
         case SchemaPrimitive::Float:
@@ -316,7 +315,6 @@ bool up::reflex::_detail::decodeValue(nlohmann::json const& json, Schema const& 
             static_cast<glm::vec3*>(obj)->y = json[1].get<float>();
             static_cast<glm::vec3*>(obj)->z = json[2].get<float>();
             return true;
-        case SchemaPrimitive::Mat4x4:
         case SchemaPrimitive::Quat:
             return false;
         case SchemaPrimitive::Float:

--- a/potato/spud/CMakeLists.txt
+++ b/potato/spud/CMakeLists.txt
@@ -13,6 +13,8 @@ add_library(potato::spud ALIAS potato_spud)
 #    "include/potato/spud/map.h"
 #    "include/potato/spud/overload.h"
 #    "include/potato/spud/result.h"
+#    "include/potato/spud/key.h"
+#    "include/potato/spud/static_id.h"
 #)
 
 include(up_set_common_properties)
@@ -45,7 +47,7 @@ target_sources(potato_spud_test PRIVATE
     "tests/test_string_writer.cpp"
     "tests/test_vector.cpp"
     "tests/test_zstring_view.cpp"
- "include/potato/spud/key.h" "include/potato/spud/static_id.h")
+)
 
 target_link_libraries(potato_spud INTERFACE
     nanofmt::nanofmt

--- a/potato/spud/include/potato/spud/ascii.h
+++ b/potato/spud/include/potato/spud/ascii.h
@@ -9,6 +9,10 @@ namespace up::ascii {
         return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
     }
 
+    constexpr auto is_lower(char const ch) noexcept -> bool { return ch >= 'a' && ch <= 'z'; }
+
+    constexpr auto is_upper(char const ch) noexcept -> bool { return ch >= 'A' && ch <= 'Z'; }
+
     constexpr auto is_alnum(char const ch) noexcept -> bool { return is_digit(ch) || is_alpha(ch); }
 
     constexpr auto is_hex_digit(char const ch) noexcept -> bool {

--- a/potato/spud/include/potato/spud/memory_util.h
+++ b/potato/spud/include/potato/spud/memory_util.h
@@ -36,10 +36,8 @@ namespace up {
 template <typename InputIt, typename SizeT>
 void up::default_construct_n(InputIt first, SizeT count) {
     using type = std::remove_reference_t<decltype(*first)>;
-    if constexpr (!std::is_trivially_constructible_v<type>) {
-        while (count-- > 0) {
-            new (first++) type{};
-        }
+    while (count-- > 0) {
+        new (first++) type{};
     }
 }
 

--- a/resources/scenes/test.scene
+++ b/resources/scenes/test.scene
@@ -34,11 +34,7 @@
                     },
                     {
                         "$schema": "Body",
-                        "linearVelocity": [
-                            4.0,
-                            12.0,
-                            -9.0
-                        ]
+                        "mass": 0.0
                     }
                 ],
                 "name": "Center"
@@ -3383,7 +3379,14 @@
                 "name": "Ring"
             }
         ],
-        "components": [],
+        "components": [
+            {
+                "$schema": "Test",
+                "integer": 0,
+                "real": 7.550000190734863,
+                "text": "hmm"
+            }
+        ],
         "name": "Root"
     }
 }

--- a/resources/scenes/test.scene
+++ b/resources/scenes/test.scene
@@ -3382,9 +3382,33 @@
         "components": [
             {
                 "$schema": "Test",
+                "angles": {
+                    "$schema": "Euler",
+                    "pitch": 0.0,
+                    "roll": 0.0,
+                    "yaw": 0.0
+                },
+                "array": [],
+                "embedded": null,
+                "enabled": false,
                 "integer": 0,
+                "limit": 0,
+                "numbers": [
+                    1001,
+                    2002,
+                    3003,
+                    4004,
+                    5005
+                ],
                 "real": 7.550000190734863,
-                "text": "hmm"
+                "ref": null,
+                "rot": null,
+                "text": "hmm",
+                "vec": [
+                    0.0,
+                    0.0,
+                    0.0
+                ]
             }
         ],
         "name": "Root"


### PR DESCRIPTION
- Refactored Property Grid
- Custom Property Editors can be defined per primitive type (eventually: schema type customization)
- Property Grid is an app-level object, not per-document (for sharing custom editors)
- Layout refresh of Property Grid
- Prettified Property names
- General imgui style tweaks
- Schema refinements to better support Property Grid
- Various fixes

![image](https://user-images.githubusercontent.com/1817473/153285033-72db41e4-ec34-40ee-813a-411faaf02505.png)
