### PR TITLE
Fix the basics of Asset Browser... by fixing codegen

### DIFF
--- a/potato/bin_codegen/source/generators/schema_source_gen.cpp
+++ b/potato/bin_codegen/source/generators/schema_source_gen.cpp
@@ -213,7 +213,7 @@ void SchemaSourceGenerator::writeSchema() {
 void SchemaSourceGenerator::writeObjectSchema(schema::TypeAggregate const& type) {
     using namespace schema;
 
-    bool const isAssetRef = hasAnnotation(type.annotations, "AssetReference");
+    bool const isAssetRef = hasAnnotation(type.annotations, "AssetType");
 
     if (!static_cast<TypeAggregate const&>(type).fields.empty()) {
         for (auto const* const field : type.fields) {

--- a/potato/bin_shell/schema/scene.sap
+++ b/potato/bin_shell/schema/scene.sap
@@ -13,8 +13,8 @@ scene_component Transform {
 }
 
 scene_component Mesh {
-    MeshRef mesh;
-    MaterialRef material;
+    MeshAsset mesh;
+    MaterialAsset material;
 }
 
 scene_component Wave {
@@ -28,7 +28,7 @@ scene_component Spin {
 scene_component Ding {
     [FloatRange(0, 3600)]
     float period = 1;
-    SoundRef sound;
+    SoundAsset sound;
 }
 
 scene_component Body {
@@ -55,5 +55,7 @@ scene_component Test {
     int[] numbers;
     Euler[] euler_array;
     Euler* euler_object;
+
+    MeshAsset mesh;
 }
 

--- a/potato/libaudio/schema/sound.sap
+++ b/potato/libaudio/schema/sound.sap
@@ -2,8 +2,6 @@ module sound;
 
 import common;
 
-[cxximport("up::SoundResource", "potato/audio/sound_resource.h")]
+[cxximport("up::AssetHandle<up::SoundResource>", "potato/audio/sound_resource.h")]
 [AssetType("potato.asset.sound")]
-using SoundAsset;
-
-using SoundRef = AssetRef<SoundAsset>;
+struct SoundAsset { }

--- a/potato/libreflex/include/potato/reflex/schema.h
+++ b/potato/libreflex/include/potato/reflex/schema.h
@@ -115,7 +115,7 @@ namespace up::reflex {
         AttributeT const* queryAnnotation() const noexcept requires(std::is_base_of_v<SchemaAttribute, AttributeT>) {
             TypeInfo const& type = TypeHolder<AttributeT>::get();
             for (SchemaAnnotation const& anno : annotations) {
-                if (anno.type == &type) {
+                if (anno.type->hash == type.hash) {
                     return static_cast<AttributeT const*>(anno.attr);
                 }
             }
@@ -318,7 +318,7 @@ namespace up::reflex {
     constexpr auto queryAnnotation(view<SchemaAnnotation> annotations) noexcept -> AttributeT const* {
         TypeInfo const& type = TypeHolder<AttributeT>::get();
         for (SchemaAnnotation const& anno : annotations) {
-            if (anno.type == &type) {
+            if (anno.type->hash == type.hash) {
                 return static_cast<AttributeT const*>(anno.attr);
             }
         }

--- a/potato/libreflex/include/potato/reflex/schema.h
+++ b/potato/libreflex/include/potato/reflex/schema.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "traits.h"
+#include "type.h"
 
 #include "potato/spud/box.h"
 #include "potato/spud/concepts.h"

--- a/potato/libreflex/schema/common.sap
+++ b/potato/libreflex/schema/common.sap
@@ -30,13 +30,8 @@ attribute Hidden;
 attribute Flatten;
 attribute Tooltip { string text; }
 attribute AssetType { string assetType; }
-attribute AssetReference;
 attribute IntRange { int min; int max; }
 attribute FloatRange { float min; float max; }
-
-[cxximport("up::AssetHandle<$AssetT>", "potato/runtime/asset.h")]
-[AssetReference]
-struct AssetRef<AssetT> { }
 
 // useful types for source content
 struct Euler {

--- a/potato/librender/schema/material.sap
+++ b/potato/librender/schema/material.sap
@@ -2,33 +2,28 @@ module material;
 
 import common;
 
-[cxximport("up::Shader", "potato/render/shader.h")]
+[cxximport("up::AssetHandle<up::Shader>", "potato/render/shader.h")]
 [AssetType("potato.asset.shader")]
-using ShaderAsset;
+struct ShaderAsset { }
 
-[cxximport("up::Mesh", "potato/render/mesh.h")]
+[cxximport("up::AssetHandle<up::Mesh>", "potato/render/mesh.h")]
 [AssetType("potato.asset.model")]
-using MeshAsset;
+struct MeshAsset { }
 
-[cxximport("up::Material", "potato/render/material.h")]
+[cxximport("up::AssetHandle<up::Material>", "potato/render/material.h")]
 [AssetType("potato.asset.material")]
-using MaterialAsset;
+struct MaterialAsset { }
 
-[cxximport("up::Texture", "potato/render/texture.h")]
+[cxximport("up::AssetHandle<up::Texture>", "potato/render/texture.h")]
 [AssetType("potato.asset.texture")]
-using TextureAsset;
-
-using ShaderRef = AssetRef<ShaderAsset>;
-using MeshRef = AssetRef<MeshAsset>;
-using MaterialRef = AssetRef<MaterialAsset>;
-using TextureRef = AssetRef<TextureAsset>;
+struct TextureAsset { }
 
 struct MaterialShaders {
-    ShaderRef vertex;
-    ShaderRef pixel;
+    ShaderAsset vertex;
+    ShaderAsset pixel;
 }
 
 struct Material {
     MaterialShaders shaders;
-    TextureRef[] textures;
+    TextureAsset[] textures;
 }

--- a/scripts/config/launch.vs.json.in
+++ b/scripts/config/launch.vs.json.in
@@ -7,7 +7,7 @@
       "project": "CMakeLists.txt",
       "projectTarget": "test_runtime.exe (bin\\test_runtime.exe)",
       "name": "test_runtime.exe (bin\\test_runtime.exe)",
-      "currentDir": "@UP_ROOT_DIR@/source/libruntime/tests/fixtures"
+      "currentDir": "@UP_ROOT_DIR@/potato/libruntime/tests/fixtures"
     },
     {
       "type": "default",
@@ -20,6 +20,19 @@
         "@UP_ROOT_DIR@/resources",
         "-config",
         "@CMAKE_RUNTIME_OUTPUT_DIRECTORY@/recon.config.json"
+      ]
+    },
+    {
+      "type": "default",
+      "project": "CMakeLists.txt",
+      "projectTarget": "bin_codegen.exe (bin\\bin_codegen.exe)",
+      "name": "bin_codegen.exe (bin\\bin_codegen.exe)",
+      "currentDir": "@CMAKE_BINARY_DIR@",
+      "args": [
+        "-m",
+        "schema_source",
+        "-i",
+        "@CMAKE_OUTPUT_DIRECTORY@/potato/librender/gen/sap/material.json"
       ]
     }
   ]


### PR DESCRIPTION
Closes #323 

The AssetRef templates were losing the attribute. Rather than fix that, I decided that having to declare every Asset type twice in IDL is silly and just flatted those declarations.