### PR TITLE
Update imgui to 1.87-WIP

### DIFF
--- a/depends.cmake
+++ b/depends.cmake
@@ -18,7 +18,7 @@ up_require(catch2
 )
 up_require(imgui
     GIT_REPOSITORY git://github.com/ocornut/imgui.git
-    GIT_COMMIT bac748fa95ac003c7b354139980f8b4b7f6ac5da
+    GIT_COMMIT 0647ba3badb9db94cb2dbc971cfc034e1c72f48a
     CMAKE_FILE imgui.cmake
 )
 up_require(glm

--- a/external/imgui.cmake
+++ b/external/imgui.cmake
@@ -33,3 +33,7 @@ target_sources(imgui_backend_sdl INTERFACE
     "${imgui_SOURCE_DIR}/backends/imgui_impl_sdl.cpp"
     "${imgui_SOURCE_DIR}/backends/imgui_impl_sdl.h"
 )
+# bug in 1.87 WIP - remove when it's fixed
+target_compile_options(imgui_backend_sdl INTERFACE
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-error=array-bounds>
+)


### PR DESCRIPTION
We don't update all the way to 1.87 due to a bug with mouse input, the SDL backend, and the docking branch.