### PR TITLE
Treat most external library headers paths as SYSTEM headers

### DIFF
--- a/external/dx12memalloc.cmake
+++ b/external/dx12memalloc.cmake
@@ -1,7 +1,7 @@
 FetchContent_Populate(dx12memalloc)
 add_library(dx12memalloc STATIC)
 target_include_directories(dx12memalloc
-    PUBLIC "${dx12memalloc_SOURCE_DIR}/include"
+    SYSTEM PUBLIC "${dx12memalloc_SOURCE_DIR}/include"
     PRIVATE "${dx12memalloc_SOURCE_DIR}/src"
 )
 

--- a/external/imgui.cmake
+++ b/external/imgui.cmake
@@ -1,6 +1,6 @@
 FetchContent_Populate(imgui)
 add_library(imgui STATIC EXCLUDE_FROM_ALL)
-target_include_directories(imgui PUBLIC "${imgui_SOURCE_DIR}")
+target_include_directories(imgui SYSTEM PUBLIC "${imgui_SOURCE_DIR}")
 target_sources(imgui PRIVATE
     "${imgui_SOURCE_DIR}/imgui.cpp"
     "${imgui_SOURCE_DIR}/imgui_demo.cpp"

--- a/external/libuv.cmake
+++ b/external/libuv.cmake
@@ -24,5 +24,5 @@ else()
 
     add_library(uv INTERFACE)
     target_link_libraries(uv INTERFACE ${libuv_LIBRARY})
-    target_include_directories(uv INTERFACE ${libuv_INCLUDE_DIR})
+    target_include_directories(uv SYSTEM INTERFACE ${libuv_INCLUDE_DIR})
 endif()

--- a/external/nfd.cmake
+++ b/external/nfd.cmake
@@ -7,6 +7,6 @@ target_sources(nfd PRIVATE
     "$<$<PLATFORM_ID:Darwin>:${nfd_SOURCE_DIR}/src/nfd_cocoa.m>"
     "$<$<PLATFORM_ID:Windows>:${nfd_SOURCE_DIR}/src/nfd_win.cpp>"
 )
-target_include_directories(nfd PUBLIC "${nfd_SOURCE_DIR}/src/include")
+target_include_directories(nfd SYSTEM PUBLIC "${nfd_SOURCE_DIR}/src/include")
 target_compile_definitions(nfd PRIVATE _CRT_SECURE_NO_WARNINGS=1)
 target_compile_options(nfd PRIVATE $<$<C_COMPILER_ID:GNU>:-Wno-format-truncation>)

--- a/external/soloud.cmake
+++ b/external/soloud.cmake
@@ -1,7 +1,7 @@
 FetchContent_Populate(soloud)
 
 add_library(soloud STATIC EXCLUDE_FROM_ALL)
-target_include_directories(soloud PUBLIC "${soloud_SOURCE_DIR}/include")
+target_include_directories(soloud SYSTEM PUBLIC "${soloud_SOURCE_DIR}/include")
 target_compile_definitions(soloud
     PRIVATE
         WITH_SDL2_STATIC=1

--- a/external/sqlite.cmake
+++ b/external/sqlite.cmake
@@ -5,6 +5,6 @@ add_library(sqlite3 STATIC EXCLUDE_FROM_ALL
     "${sqlite_source_SOURCE_DIR}/sqlite3.h"
     "${sqlite_source_SOURCE_DIR}/sqlite3ext.h"
 )
-target_include_directories(sqlite3 PUBLIC ${sqlite_source_SOURCE_DIR})
+target_include_directories(sqlite3 SYSTEM PUBLIC ${sqlite_source_SOURCE_DIR})
 set_target_properties(sqlite3 PROPERTIES POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 target_link_libraries(sqlite3 PUBLIC ${CMAKE_DL_LIBS})

--- a/external/stb.cmake
+++ b/external/stb.cmake
@@ -1,3 +1,3 @@
 FetchContent_Populate(stb)
 add_library(stb INTERFACE)
-target_include_directories(stb INTERFACE "${stb_SOURCE_DIR}")
+target_include_directories(stb SYSTEM INTERFACE "${stb_SOURCE_DIR}")

--- a/external/tracy.cmake
+++ b/external/tracy.cmake
@@ -4,7 +4,7 @@ target_sources(tracy PRIVATE
     "${tracy_SOURCE_DIR}/TracyClient.cpp"
     "${tracy_SOURCE_DIR}/Tracy.hpp"
 )
-target_include_directories(tracy PUBLIC "${tracy_SOURCE_DIR}")
+target_include_directories(tracy SYSTEM PUBLIC "${tracy_SOURCE_DIR}")
 target_compile_definitions(tracy
     PUBLIC
         TRACY_ENABLE=1


### PR DESCRIPTION
Since VS upgrades introduce warnings that break third-party code.